### PR TITLE
Add `extrapolate` and `extrapolate!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegisterDeformation"
 uuid = "c19381b7-cf49-59d7-881c-50dfbd227eaf"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
@@ -31,7 +31,7 @@ AxisArrays = "0.3, 0.4"
 CoordinateTransformations = "0.5"
 FileIO = "1"
 ForwardDiff = "0.10"
-HDF5 = "0.10, 0.11, 0.12"
+HDF5 = "0.10, 0.11, 0.12, 0.13"
 ImageAxes = "0.5, 0.6"
 ImageCore = "0.8.1"
 ImageTransformations = "0.8"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -15,6 +15,8 @@ similarϕ
 ```@docs
 interpolate(::GridDeformation)
 interpolate!(::GridDeformation)
+extrapolate(::GridDeformation)
+extrapolate!(::GridDeformation)
 ```
 
 ## Warping images

--- a/src/RegisterDeformation.jl
+++ b/src/RegisterDeformation.jl
@@ -21,6 +21,8 @@ export
     centeraxes,
     compose,
     eachnode,
+    extrapolate,
+    extrapolate!,
     getindex!,
     griddeformations,
     interpolate,


### PR DESCRIPTION
Traditionally we've allowed composition of two deformations to error if the "correction" is so large that it goes out-of-bounds. But there are good reasons to permit living dangerously as long as the user takes responsibility for the outcome. This adds `extrapolate` support for deformations.

Fixes #7. CC @ChantalJuntao 
