### PR TITLE
Bump CoordinateTransformations compat to include 0.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ deps/deps.jl
 Manifest.toml
 docs/build
 docs/site
+.vscode/

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegisterDeformation"
 uuid = "c19381b7-cf49-59d7-881c-50dfbd227eaf"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
@@ -28,7 +28,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 AxisArrays = "0.3, 0.4"
-CoordinateTransformations = "0.5"
+CoordinateTransformations = "0.5, 0.6"
 FileIO = "1"
 ForwardDiff = "0.10"
 HDF5 = "0.14, 0.15"


### PR DESCRIPTION
This PR bumps the CoordinateTransformations package compat so that it includes 0.6.