### PR TITLE
Stop importing CT.transform

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         version:
           - '1.3'
+          - '1.6'
           - '1'
 #          - 'nightly'
         os:

--- a/src/RegisterDeformation.jl
+++ b/src/RegisterDeformation.jl
@@ -8,7 +8,7 @@ using Interpolations: AbstractInterpolation, AbstractExtrapolation
 import ImageTransformations: warp, warp!
 # to avoid `scale` conflict with Interpolations, selectively import CoordinateTransformations:
 using CoordinateTransformations: AffineMap
-import CoordinateTransformations: compose, transform
+import CoordinateTransformations: compose
 using OffsetArrays: IdentityUnitRange   # for Julia-version compatibility
 
 export


### PR DESCRIPTION
This was deprecated in
https://github.com/JuliaGeometry/CoordinateTransformations.jl/pull/8