### PR TITLE
Fix arraysize import in tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 #import BlockRegistration
 using RegisterDeformation
+using RegisterDeformation: arraysize
 using CoordinateTransformations, Interpolations, ImageCore, ForwardDiff
 using StaticArrays, LinearAlgebra, Distributed, Statistics
 using AxisArrays: AxisArray


### PR DESCRIPTION
Not sure why it started being a problem because `Base` doesn't export `arraysize` 

```
julia> arraysize
ERROR: UndefVarError: `arraysize` not defined in `Main`
Hint: It looks like two or more modules export different bindings with this name, resulting in ambiguity. Try explicitly importing it from a particular module, or qualifying the name with the module it should come from.
Hint: a global variable of this name also exists in RegisterDeformation.
```