### PR TITLE
Apply runic formatting

### DIFF
--- a/src/RegisterDeformation.jl
+++ b/src/RegisterDeformation.jl
@@ -18,7 +18,7 @@ export
     NodeIterator,
     WarpedArray,
     # functions
-    arraysize,       # TODO: don't export?
+    arraysize, # TODO: don't export?
     centeraxes,
     compose,
     eachnode,
@@ -36,8 +36,8 @@ export
     tmedfilt,
     tmedfilt!,
     translate,
-    vecindex,        # TODO: don't export?
-    vecgradient!,    # TODO: don't export?
+    vecindex, # TODO: don't export?
+    vecgradient!, # TODO: don't export?
     warp,
     warp!,
     warpgrid,
@@ -52,7 +52,7 @@ export
     transform
 
 const DimsLike = Union{Vector{Int}, Dims}
-const InterpExtrap = Union{AbstractInterpolation,AbstractExtrapolation}
+const InterpExtrap = Union{AbstractInterpolation, AbstractExtrapolation}
 
 """
 # RegisterDeformation
@@ -82,11 +82,11 @@ The major functions/types exported by RegisterDeformation are:
 """
 RegisterDeformation
 
-abstract type AbstractDeformation{T,N} end
-Base.eltype(::Type{AbstractDeformation{T,N}}) where {T,N} = T
-Base.ndims(::Type{AbstractDeformation{T,N}}) where {T,N} = N
-Base.eltype(::Type{D}) where {D<:AbstractDeformation} = eltype(supertype(D))
-Base.ndims(::Type{D}) where {D<:AbstractDeformation} = ndims(supertype(D))
+abstract type AbstractDeformation{T, N} end
+Base.eltype(::Type{AbstractDeformation{T, N}}) where {T, N} = T
+Base.ndims(::Type{AbstractDeformation{T, N}}) where {T, N} = N
+Base.eltype(::Type{D}) where {D <: AbstractDeformation} = eltype(supertype(D))
+Base.ndims(::Type{D}) where {D <: AbstractDeformation} = ndims(supertype(D))
 Base.eltype(d::AbstractDeformation) = eltype(typeof(d))
 Base.ndims(d::AbstractDeformation) = ndims(typeof(d))
 
@@ -94,7 +94,7 @@ include("griddeformation.jl")
 include("utils.jl")
 include("timeseries.jl")
 include("tformedarrays.jl")
-const Extrapolatable{T,N} = Union{TransformedArray{T,N},AbstractExtrapolation{T,N}}
+const Extrapolatable{T, N} = Union{TransformedArray{T, N}, AbstractExtrapolation{T, N}}
 include("warpedarray.jl")
 include("warp.jl")
 include("visualize.jl")

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -10,41 +10,45 @@
     error("field ", name, " is not available")
 end
 
-function GridDeformation(u::AbstractArray{FV,N},
-                         sz::NTuple{N,L}) where {FV<:SVector,N,L<:Integer}
+function GridDeformation(
+        u::AbstractArray{FV, N},
+        sz::NTuple{N, L}
+    ) where {FV <: SVector, N, L <: Integer}
     Base.depwarn("`GridDeformation(u, size(fixed))` is deprecated, use `GridDeformation(u, axes(fixed))` instead.", :GridDeformation)
     return GridDeformation(u, map(Base.OneTo, sz))
 end
 
 # The above causes an ambiguity, resolve it
-function GridDeformation(u::AbstractArray{FV,0}, nodes::Tuple{}) where FV<:SVector
+function GridDeformation(u::AbstractArray{FV, 0}, nodes::Tuple{}) where {FV <: SVector}
     error("node tuple cannot be empty")
 end
 
 function GridDeformation(u, nodes::AbstractVector{<:Integer})
     Base.depwarn("`GridDeformation(u, [size(fixed)...])` is deprecated, pass the axes of `fixed` instead.", :GridDeformation)
-    GridDeformation(u, map(Base.OneTo, (nodes...,)))
+    return GridDeformation(u, map(Base.OneTo, (nodes...,)))
 end
 
-function tform2deformation(tform::AffineMap{M,V}, arraysize::DimsLike, gridsize) where {M,V}
-    Base.depwarn("""
-    `tform2deformation(tform, arraysize, gridsize)` is deprecated.
-    Formerly, `tform` was defined so as to apply to `centered(img)`, which shifts
-    the axes of `img` to put 0 at the midpoint of `img`.
-    Now you should call this as `tform2deformation(tform, axs, gridsize)`, where
-    `axs` represents the desired domain of `tform`.
-    If you are transitioning old code, either use `axs = axes(fixed)` if `fixed`
-    is already centered, or `axs = centeraxes(axes(fixed))` if not.
-    """, :tform2deformation)
+function tform2deformation(tform::AffineMap{M, V}, arraysize::DimsLike, gridsize) where {M, V}
+    Base.depwarn(
+        """
+        `tform2deformation(tform, arraysize, gridsize)` is deprecated.
+        Formerly, `tform` was defined so as to apply to `centered(img)`, which shifts
+        the axes of `img` to put 0 at the midpoint of `img`.
+        Now you should call this as `tform2deformation(tform, axs, gridsize)`, where
+        `axs` represents the desired domain of `tform`.
+        If you are transitioning old code, either use `axs = axes(fixed)` if `fixed`
+        is already centered, or `axs = centeraxes(axes(fixed))` if not.
+        """, :tform2deformation
+    )
     axs = map((arraysize...,)) do sz
         halfsz = sz ÷ 2
-        IdentityUnitRange(1-halfsz:sz-halfsz)
+        IdentityUnitRange((1 - halfsz):(sz - halfsz))
     end
     return tform2deformation(tform, axs, (gridsize...,))
 end
 
 import Base: getindex
-@deprecate getindex(ϕ::GridDeformation{T,N,A}, xs::Vararg{Number,N}) where {T,N,A<:AbstractInterpolation} ϕ(xs...)
+@deprecate getindex(ϕ::GridDeformation{T, N, A}, xs::Vararg{Number, N}) where {T, N, A <: AbstractInterpolation} ϕ(xs...)
 
 Base.@deprecate_binding eachknot eachnode
 Base.@deprecate_binding knotgrid nodegrid
@@ -53,17 +57,17 @@ Base.@deprecate_binding knotgrid nodegrid
 @deprecate similarϕ(ϕref, coefs) similar_deformation(ϕref, coefs)
 
 # medfilt → tmedfilt
-@deprecate medfilt(ϕs::AbstractVector{D}, n) where D<:AbstractDeformation tmedfilt(ϕs, n)
+@deprecate medfilt(ϕs::AbstractVector{D}, n) where {D <: AbstractDeformation} tmedfilt(ϕs, n)
 
 # compose(f::Function, ϕ) where f ≠ identity — the signature now requires typeof(identity)
-function compose(f::Function, ϕ_new::GridDeformation{T,N}) where {T,N}
+function compose(f::Function, ϕ_new::GridDeformation{T, N}) where {T, N}
     f == identity || error("Only the identity function is supported")
     Base.depwarn("`compose(f, ϕ)` with a `Function` argument is deprecated; use `compose(identity, ϕ)` directly.", :compose)
-    compose(identity, ϕ_new)
+    return compose(identity, ϕ_new)
 end
 
 # warp!(::Type{T}, dest, img, ϕs; ...) → warp!(dest, img, ϕs; eltype=T, ...)
-function warp!(::Type{T}, dest::Union{IO,HDF5.Dataset,JLD2.JLDFile}, img, ϕs; kwargs...) where T
+function warp!(::Type{T}, dest::Union{IO, HDF5.Dataset, JLD2.JLDFile}, img, ϕs; kwargs...) where {T}
     Base.depwarn("`warp!(T, dest, img, ϕs)` is deprecated; use `warp!(dest, img, ϕs; eltype=T)` instead.", :warp!)
-    warp!(dest, img, ϕs; eltype=T, kwargs...)
+    return warp!(dest, img, ϕs; eltype = T, kwargs...)
 end

--- a/src/griddeformation.jl
+++ b/src/griddeformation.jl
@@ -31,71 +31,75 @@ nodes = (range(1, stop=100, length=gridsize[1]), range(1, stop=200, length=grids
 ϕ = GridDeformation(u, nodes) # this is a "naive" deformation (not ready for interpolation)
 ```
 """
-struct GridDeformation{T,N,A<:AbstractArray,L} <: AbstractDeformation{T,N}
+struct GridDeformation{T, N, A <: AbstractArray, L} <: AbstractDeformation{T, N}
     u::A
-    nodes::NTuple{N,L}
+    nodes::NTuple{N, L}
 
-    function GridDeformation{T,N,A,L}(u::AbstractArray{FV,N}, nodes::NTuple{N,L}) where {T,N,A,L,FV<:SVector}
+    function GridDeformation{T, N, A, L}(u::AbstractArray{FV, N}, nodes::NTuple{N, L}) where {T, N, A, L, FV <: SVector}
         typeof(u) == A || error("typeof(u) = $(typeof(u)), which is different from $A")
         length(FV) == N || throw(DimensionMismatch("Dimensionality $(length(FV)) must match $N node vectors"))
-        for d = 1:N
+        for d in 1:N
             size(u, d) == length(nodes[d]) || error("size(u) = $(size(u)), but the nodes specify a grid of size $(map(length, nodes))")
         end
-        new{T,N,A,L}(u, nodes)
+        return new{T, N, A, L}(u, nodes)
     end
-    function GridDeformation{T,N,A,L}(u::ScaledInterpolation{FV,N}) where {T,N,A,L,FV<:SVector}
-        new{T,N,A,L}(u, u.ranges)
+    function GridDeformation{T, N, A, L}(u::ScaledInterpolation{FV, N}) where {T, N, A, L, FV <: SVector}
+        return new{T, N, A, L}(u, u.ranges)
     end
 end
 
-const InterpolatingDeformation{T,N,A<:AbstractInterpolation} = GridDeformation{T,N,A}
+const InterpolatingDeformation{T, N, A <: AbstractInterpolation} = GridDeformation{T, N, A}
 
 # With node ranges
-function GridDeformation(u::AbstractArray{FV,N},
-                         nodes::NTuple{N,L}) where {FV<:SVector,N,L<:AbstractVector}
+function GridDeformation(
+        u::AbstractArray{FV, N},
+        nodes::NTuple{N, L}
+    ) where {FV <: SVector, N, L <: AbstractVector}
     T = eltype(FV)
     length(FV) == N || throw(DimensionMismatch("$N-dimensional array requires SVector{$N,T}"))
-    GridDeformation{T,N,typeof(u),L}(u, nodes)
+    return GridDeformation{T, N, typeof(u), L}(u, nodes)
 end
 
 # With image axes
-function GridDeformation(u::AbstractArray{FV,N},
-                         axs::NTuple{N,L}) where {FV<:SVector,N,L<:AbstractUnitRange{<:Integer}}
+function GridDeformation(
+        u::AbstractArray{FV, N},
+        axs::NTuple{N, L}
+    ) where {FV <: SVector, N, L <: AbstractUnitRange{<:Integer}}
     T = eltype(FV)
     length(FV) == N || throw(DimensionMismatch("$N-dimensional array requires SVector{$N,T}"))
     nodes = ntuple(N) do d
         ax = axs[d]
-        range(first(ax), stop=last(ax), length=size(u,d))
+        range(first(ax), stop = last(ax), length = size(u, d))
     end
-    GridDeformation{T,N,typeof(u),typeof(nodes[1])}(u, nodes)
+    return GridDeformation{T, N, typeof(u), typeof(nodes[1])}(u, nodes)
 end
 
 # Construct from a plain array
-function GridDeformation(u::AbstractArray{T}, nodes::NTuple{N}) where {T<:Number,N}
-    ndims(u) == N+1 || error("`u` needs $(N+1) dimensions for $N-dimensional deformations")
+function GridDeformation(u::AbstractArray{T}, nodes::NTuple{N}) where {T <: Number, N}
+    ndims(u) == N + 1 || error("`u` needs $(N + 1) dimensions for $N-dimensional deformations")
     size(u, 1) == N || error("first dimension of u must be of length $N")
-    uf = Array(convert_to_fixed(SVector{N,T}, u, tail(size(u))))
-    GridDeformation(uf, nodes)
+    uf = Array(convert_to_fixed(SVector{N, T}, u, tail(size(u))))
+    return GridDeformation(uf, nodes)
 end
 
 # Construct from a (u1, u2, ...) tuple
-function GridDeformation(u::NTuple{N,AbstractArray}, nodes::NTuple{N}) where N
+function GridDeformation(u::NTuple{N, AbstractArray}, nodes::NTuple{N}) where {N}
     ndims(u[1]) == N || error("Need $N dimensions for $N-dimensional deformations")
-    ua = permutedims(cat(u..., dims=N+1), (N+1,(1:N)...))
+    ua = permutedims(cat(u..., dims = N + 1), (N + 1, (1:N)...))
     uf = Array(convert_to_fixed(ua))
-    GridDeformation(uf, nodes)
+    return GridDeformation(uf, nodes)
 end
 
 # When nodes is a vector
-GridDeformation(u, nodes::AbstractVector{V}) where {V<:AbstractVector} = GridDeformation(u, (nodes...,))
+GridDeformation(u, nodes::AbstractVector{V}) where {V <: AbstractVector} = GridDeformation(u, (nodes...,))
 
-function GridDeformation(u::ScaledInterpolation{FV}) where FV<:SVector
+function GridDeformation(u::ScaledInterpolation{FV}) where {FV <: SVector}
     N = length(FV)
     ndims(u) == N || throw(DimensionMismatch("Dimension $(ndims(u)) incompatible with vectors of length $N"))
-    GridDeformation{eltype(FV),N,typeof(u),typeof(u.ranges[1])}(u)
+    return GridDeformation{eltype(FV), N, typeof(u), typeof(u.ranges[1])}(u)
 end
 
-function Base.show(io::IO, ϕ::GridDeformation{T}) where T
+function Base.show(io::IO, ϕ::GridDeformation{T}) where {T}
     if ϕ.u isa AbstractInterpolation
         print(io, "Interpolating ")
     end
@@ -104,6 +108,7 @@ function Base.show(io::IO, ϕ::GridDeformation{T}) where T
         print(io, first(n), "..", last(n))
         i < length(ϕ.nodes) && print(io, '×')
     end
+    return
 end
 
 """
@@ -111,23 +116,23 @@ end
 seqeuential deformations.  The last dimension of the array `u` should
 correspond to time; `ϕs[i]` is produced from `u[:, ..., i]`.
 """
-function griddeformations(u::AbstractArray{T}, nodes::NTuple{N}) where {N,T<:Number}
-    ndims(u) == N+2 || error("Need $(N+2) dimensions for a vector of $N-dimensional deformations")
-    size(u,1) == N || error("First dimension of u must be of length $N")
-    uf = Array(convert_to_fixed(SVector{N,T}, u, Base.tail(size(u))))
-    griddeformations(uf, nodes)
+function griddeformations(u::AbstractArray{T}, nodes::NTuple{N}) where {N, T <: Number}
+    ndims(u) == N + 2 || error("Need $(N + 2) dimensions for a vector of $N-dimensional deformations")
+    size(u, 1) == N || error("First dimension of u must be of length $N")
+    uf = Array(convert_to_fixed(SVector{N, T}, u, Base.tail(size(u))))
+    return griddeformations(uf, nodes)
 end
 
-function griddeformations(u::AbstractArray{FV}, nodes::NTuple{N}) where {N,FV<:SVector}
-    ndims(u) == N+1 || error("Need $(N+1) dimensions for a vector of $N-dimensional deformations")
+function griddeformations(u::AbstractArray{FV}, nodes::NTuple{N}) where {N, FV <: SVector}
+    ndims(u) == N + 1 || error("Need $(N + 1) dimensions for a vector of $N-dimensional deformations")
     length(FV) == N || throw(DimensionMismatch("Dimensionality $(length(FV)) must match $N node vectors"))
-    colons = ntuple(d->Colon(), Val(N))
-    [GridDeformation(view(u, colons..., i), nodes) for i = 1:size(u, N+1)]
+    colons = ntuple(d -> Colon(), Val(N))
+    return [GridDeformation(view(u, colons..., i), nodes) for i in 1:size(u, N + 1)]
 end
 
 Base.:(==)(ϕ1::GridDeformation, ϕ2::GridDeformation) = ϕ1.u == ϕ2.u && ϕ1.nodes == ϕ2.nodes
 
-Base.copy(ϕ::GridDeformation{T,N,A,L}) where {T,N,A,L} = (u = copy(ϕ.u); GridDeformation{T,N,typeof(u),L}(u, map(copy, ϕ.nodes)))
+Base.copy(ϕ::GridDeformation{T, N, A, L}) where {T, N, A, L} = (u = copy(ϕ.u); GridDeformation{T, N, typeof(u), L}(u, map(copy, ϕ.nodes)))
 
 # # TODO: flesh this out
 # immutable VoroiDeformation{T,N,Vu<:AbstractVector,Vc<:AbstractVector} <: AbstractDeformation{T,N}
@@ -145,9 +150,9 @@ Create a deformation `ϕi` suitable for interpolation, matching the displacement
 of `ϕ.u` at the nodes. A quadratic interpolation scheme is used, with default
 flat boundary conditions.
 """
-function Interpolations.interpolate(ϕ::GridDeformation, BC=Flat(OnCell()))
+function Interpolations.interpolate(ϕ::GridDeformation, BC = Flat(OnCell()))
     itp = scale(interpolate(ϕ.u, BSpline(Quadratic(BC))), ϕ.nodes...)
-    GridDeformation(itp)
+    return GridDeformation(itp)
 end
 
 """
@@ -160,9 +165,9 @@ flat boundary conditions and `Line` extrapolation.
 !!! warning
     Extrapolation beyond the supported region of `ϕ` can yield poor results.
 """
-function Interpolations.extrapolate(ϕ::GridDeformation, BC=Flat(OnCell()))
+function Interpolations.extrapolate(ϕ::GridDeformation, BC = Flat(OnCell()))
     etp = _extrapolate(ϕ.u, ϕ.nodes, BC)
-    GridDeformation(etp)
+    return GridDeformation(etp)
 end
 
 _extrapolate(A::AbstractArray, nodes, BC) = _extrapolate(interpolate(A, BSpline(Quadratic(BC))), nodes, BC)
@@ -185,9 +190,9 @@ boundary conditions.
     When it matters, it is recommended that you annotate such calls with
     `# not same as interpolate(ϕ)` in your code.
 """
-function Interpolations.interpolate!(ϕ::GridDeformation, BC=InPlace(OnCell()))
+function Interpolations.interpolate!(ϕ::GridDeformation, BC = InPlace(OnCell()))
     itp = scale(interpolate!(ϕ.u, BSpline(Quadratic(BC))), ϕ.nodes...)
-    GridDeformation(itp)
+    return GridDeformation(itp)
 end
 
 Interpolations.interpolate(ϕ::InterpolatingDeformation, args...) = error("ϕ is already interpolating")
@@ -208,16 +213,16 @@ boundary conditions.
     When it matters, it is recommended that you annotate such calls with
     `# not same as extrapolate(ϕ)` in your code.
 """
-function extrapolate!(ϕ::GridDeformation, BC=InPlace(OnCell()))
+function extrapolate!(ϕ::GridDeformation, BC = InPlace(OnCell()))
     etp = _extrapolate!(ϕ.u, ϕ.nodes, BC)
-    GridDeformation(etp)
+    return GridDeformation(etp)
 end
 
 _extrapolate!(A, nodes, BC) = _extrapolate(interpolate!(A, BSpline(Quadratic(BC))), nodes, BC)
 _extrapolate!(A::AbstractInterpolation, nodes, BC) = error("ϕ is already interpolating")
 
-function vecindex(ϕ::GridDeformation{T,N,A}, x::SVector{N}) where {T,N,A<:AbstractInterpolation}
-    x + vecindex(ϕ.u, x)
+function vecindex(ϕ::GridDeformation{T, N, A}, x::SVector{N}) where {T, N, A <: AbstractInterpolation}
+    return x + vecindex(ϕ.u, x)
 end
 
 """
@@ -237,7 +242,7 @@ rather than `interpolate(ϕ0)` (see [`interpolate!`](@ref)).
 function similar_deformation(ϕref, coefs::AbstractArray{<:Number})
     coefsref = getcoefs(ϕref)
     N = ndims(coefsref)
-    udata = convert_to_fixed(SVector{N,eltype(coefs)}, coefs, size(coefsref))
+    udata = convert_to_fixed(SVector{N, eltype(coefs)}, coefs, size(coefsref))
     return similar_deformation(ϕref, udata)
 end
 
@@ -262,24 +267,24 @@ end
 #     end
 # end
 
-@inline function (ϕ::GridDeformation{T,N,A})(xs::Vararg{Number,N}) where {T,N,A<:AbstractInterpolation}
+@inline function (ϕ::GridDeformation{T, N, A})(xs::Vararg{Number, N}) where {T, N, A <: AbstractInterpolation}
     return ϕ.u(xs...) .+ xs
 end
 
-function (ϕ::GridDeformation{T,N})(xs::Vararg{Number,N}) where {T,N}
+function (ϕ::GridDeformation{T, N})(xs::Vararg{Number, N}) where {T, N}
     error("call `ϕi = interpolate(ϕ)` and use `ϕi` for evaluating the deformation.")
 end
 
-@inline (ϕ::GridDeformation{T,N})(xs::SVector{N}) where {T,N} = ϕ(Tuple(xs)...)
+@inline (ϕ::GridDeformation{T, N})(xs::SVector{N}) where {T, N} = ϕ(Tuple(xs)...)
 
 # Composition ϕ_old(ϕ_new(x))
-function (ϕ_old::GridDeformation{T1,N,A})(ϕ_new::GridDeformation{T2,N}) where {T1,T2,N,A<:AbstractInterpolation}
+function (ϕ_old::GridDeformation{T1, N, A})(ϕ_new::GridDeformation{T2, N}) where {T1, T2, N, A <: AbstractInterpolation}
     uold, nodes = ϕ_old.u, ϕ_old.nodes
     if !isa(ϕ_new.u, AbstractInterpolation)
         ϕ_new.nodes == nodes || error("If nodes are incommensurate, ϕ_new must be interpolating")
     end
     ucomp = _compose(uold, ϕ_new.u, nodes)
-    GridDeformation(ucomp, nodes)
+    return GridDeformation(ucomp, nodes)
 end
 
 (ϕ_old::GridDeformation)(ϕ_new::GridDeformation) =
@@ -293,29 +298,29 @@ function _compose(uold, unew, nodes)
     for I in CartesianIndices(sz)
         ucomp[I] = _compose(uold, unew, node(nodes, I), I)
     end
-    ucomp
+    return ucomp
 end
 
 function _compose(uold, unew, x, i)
     dx = lookup(unew, x, i)
-    dx + vecindex(uold, x+dx)
+    return dx + vecindex(uold, x + dx)
 end
 
-lookup(u::AbstractInterpolation, x, i) = vecindex(extrapolate(u,Flat()), x) # using extrpolate to resolve BoundsError
+lookup(u::AbstractInterpolation, x, i) = vecindex(extrapolate(u, Flat()), x) # using extrpolate to resolve BoundsError
 lookup(u, x, i) = u[i]
 
-@inline function node(nodes::NTuple{N}, i::Integer) where N
+@inline function node(nodes::NTuple{N}, i::Integer) where {N}
     I = CartesianIndices(map(length, nodes))[i]
     return node(nodes, I)
 end
 
-@inline function node(nodes::NTuple{N}, I::CartesianIndex{N}) where N
+@inline function node(nodes::NTuple{N}, I::CartesianIndex{N}) where {N}
     return SVector(map(getindex, nodes, Tuple(I)))
 end
 
-arraysize(nodes::NTuple) = map(n->Int(maximum(n) - minimum(n) + 1), nodes)
+arraysize(nodes::NTuple) = map(n -> Int(maximum(n) - minimum(n) + 1), nodes)
 
-struct NodeIterator{K,N}
+struct NodeIterator{K, N}
     nodes::K
     iter::CartesianIndices{N}
 end
@@ -332,13 +337,13 @@ function Base.iterate(ki::NodeIterator)
     iterate(ki.iter) == nothing && return nothing
     I, state = iterate(ki.iter)
     k = node(ki.nodes, I)
-    k, state
+    return k, state
 end
 function Base.iterate(ki::NodeIterator, state)
     iterate(ki.iter, state) == nothing && return nothing
     I, state = iterate(ki.iter, state)
     k = node(ki.nodes, I)
-    k, state
+    return k, state
 end
 
 """
@@ -353,15 +358,15 @@ Reparametrize the deformation `ϕ` so that it has a grid size `gridsize`.
 ```
 for a 3-dimensional deformation `ϕ`.
 """
-function regrid(ϕ::InterpolatingDeformation{T,N}, sz::Dims{N}) where {T,N}
-    nodes_new = map((r,n)->range(first(r), stop=last(r), length=n), ϕ.nodes, sz)
-    u = Array{SVector{N,T},N}(undef, sz)
+function regrid(ϕ::InterpolatingDeformation{T, N}, sz::Dims{N}) where {T, N}
+    nodes_new = map((r, n) -> range(first(r), stop = last(r), length = n), ϕ.nodes, sz)
+    u = Array{SVector{N, T}, N}(undef, sz)
     for (i, k) in enumerate(eachnode(nodes_new))
         u[i] = ϕ.u(k...)
     end
-    GridDeformation(u, nodes_new)
+    return GridDeformation(u, nodes_new)
 end
-regrid(ϕ::GridDeformation{T,N}, sz::Dims{N}) where {T,N} = regrid(interpolate(ϕ), sz)
+regrid(ϕ::GridDeformation{T, N}, sz::Dims{N}) where {T, N} = regrid(interpolate(ϕ), sz)
 
 """
 `ϕ_c = ϕ_old(ϕ_new)` computes the composition of two deformations,
@@ -375,7 +380,7 @@ position `(i,j,...)`.
 You can use `_, g = compose(identity, ϕ_new)` if you need the gradient
 for when `ϕ_old` is equal to the identity transformation.
 """
-function compose(ϕ_old::GridDeformation{T1,N,A}, ϕ_new::GridDeformation{T2,N}) where {T1,T2,N,A<:AbstractInterpolation}
+function compose(ϕ_old::GridDeformation{T1, N, A}, ϕ_new::GridDeformation{T2, N}) where {T1, T2, N, A <: AbstractInterpolation}
     u, nodes = ϕ_old.u, ϕ_old.nodes
     ϕ_new.nodes == nodes || error("Not yet implemented for incommensurate nodes")
     unew = ϕ_new.u
@@ -393,9 +398,9 @@ function compose(ϕ_old::GridDeformation{T1,N,A}, ϕ_new::GridDeformation{T2,N})
         y = x + dx
         ucomp[I] = dx + vecindex(u, y)
         vecgradient!(gtmp, u, y)
-        g[I] = hcat(ntuple(d->gtmp[d], Val(N))...) + eyeN
+        g[I] = hcat(ntuple(d -> gtmp[d], Val(N))...) + eyeN
     end
-    (; ϕ=GridDeformation(ucomp, nodes), gradient=g)
+    return (; ϕ = GridDeformation(ucomp, nodes), gradient = g)
 end
 
 """
@@ -403,7 +408,7 @@ end
 `ϕsi_old` is interpolated ``ϕs_old`:
 e.g) `ϕsi_old = map(Interpolations.interpolate!, copy(ϕs_old))`
 """
-function compose(ϕsi_old::AbstractVector{G1}, ϕs_new::AbstractVector{G2}) where {G1<:GridDeformation, G2<:GridDeformation}
+function compose(ϕsi_old::AbstractVector{G1}, ϕs_new::AbstractVector{G2}) where {G1 <: GridDeformation, G2 <: GridDeformation}
     n = length(ϕs_new)
     length(ϕsi_old) == n || throw(DimensionMismatch("vectors-of-deformations must have the same length, got $(length(ϕsi_old)) and $n"))
     r1 = compose(first(ϕsi_old), first(ϕs_new))
@@ -414,12 +419,12 @@ function compose(ϕsi_old::AbstractVector{G1}, ϕs_new::AbstractVector{G2}) wher
         ri = compose(ϕsi_old[i], ϕs_new[i])
         ϕs_c[i], gs[i] = ri.ϕ, ri.gradient
     end
-    (; ϕ=ϕs_c, gradient=gs)
+    return (; ϕ = ϕs_c, gradient = gs)
 end
 
 
-function compose(::typeof(identity), ϕ_new::GridDeformation{T,N}) where {T,N}
-    (; ϕ=ϕ_new, gradient=fill(similar_type(SArray, T, Size(N, N))(1.0I), size(ϕ_new.u)))
+function compose(::typeof(identity), ϕ_new::GridDeformation{T, N}) where {T, N}
+    return (; ϕ = ϕ_new, gradient = fill(similar_type(SArray, T, Size(N, N))(1.0I), size(ϕ_new.u)))
 end
 
 """
@@ -433,19 +438,21 @@ match that specified by `arraysize` and `gridsize`.
 Note it's more accurate to `warp(img, tform)` directly; the main use of this function
 is to initialize a GridDeformation for later optimization.
 """
-function tform2deformation(tform::AffineMap{M,V},
-                           imgaxes::NTuple{N,<:AbstractUnitRange},
-                           gridsize::NTuple{N,<:Integer}) where {M,V,N}
+function tform2deformation(
+        tform::AffineMap{M, V},
+        imgaxes::NTuple{N, <:AbstractUnitRange},
+        gridsize::NTuple{N, <:Integer}
+    ) where {M, V, N}
     A = deltalinear(tform.linear)
-    u = Array{SVector{N,eltype(M)}}(undef, gridsize...)
+    u = Array{SVector{N, eltype(M)}}(undef, gridsize...)
     nodes = map(imgaxes, gridsize) do ax, g
-        range(first(ax), stop=last(ax), length=g)
+        range(first(ax), stop = last(ax), length = g)
     end
     for I in CartesianIndices(gridsize)
         x = SVector(map(getindex, nodes, Tuple(I)))
-        u[I] = A*x + tform.translation
+        u[I] = A * x + tform.translation
     end
-    GridDeformation(u, nodes)
+    return GridDeformation(u, nodes)
 end
 
 """
@@ -453,5 +460,5 @@ end
 
 Compute the difference between `linear` and the identity transformation.
 """
-deltalinear(scale::Number) = (scale - 1)*I
+deltalinear(scale::Number) = (scale - 1) * I
 deltalinear(mtrx::AbstractMatrix) = mtrx - I

--- a/src/tformedarrays.jl
+++ b/src/tformedarrays.jl
@@ -15,37 +15,37 @@ A = TransformedArray(etp, tfm)
 where `etp` is an extrapolation object as defined by the
 Interpolations package, and `tfm` is an `AffineMap`.
 """
-struct TransformedArray{T,N,E<:AbstractExtrapolation,Tf<:AffineMap} <: AbstractArray{T,N}
+struct TransformedArray{T, N, E <: AbstractExtrapolation, Tf <: AffineMap} <: AbstractArray{T, N}
     data::E
     tform::Tf
 end
-TransformedArray(etp::AbstractExtrapolation{T,N}, a::AffineMap) where {T,N} =
-    TransformedArray{T,N,typeof(etp),typeof(a)}(etp, a)
+TransformedArray(etp::AbstractExtrapolation{T, N}, a::AffineMap) where {T, N} =
+    TransformedArray{T, N, typeof(etp), typeof(a)}(etp, a)
 
 function TransformedArray(A::AbstractInterpolation, a::AffineMap)
     etp = extrapolate(A, NaN)
-    TransformedArray(etp, a)
+    return TransformedArray(etp, a)
 end
 
 function TransformedArray(A::AbstractArray, a::AffineMap)
     itp = interpolate(A, BSpline(Linear()))
-    TransformedArray(itp, a)
+    return TransformedArray(itp, a)
 end
 
 
 Base.size(A::TransformedArray) = size(A.data)
 
-function Base.getindex(A::TransformedArray{T,2}, i::Number, j::Number) where T
-    x, y = A.tform([i,j]) #tformfwd(A.tform, i, j)
-    A.data(x, y)
+function Base.getindex(A::TransformedArray{T, 2}, i::Number, j::Number) where {T}
+    x, y = A.tform([i, j]) #tformfwd(A.tform, i, j)
+    return A.data(x, y)
 end
 
-function Base.getindex(A::TransformedArray{T,3}, i::Number, j::Number, k::Number) where T
-    x, y, z = A.tform([i,j,k]) #tformfwd(A.tform, i, j, k)
-    A.data(x, y, z)
+function Base.getindex(A::TransformedArray{T, 3}, i::Number, j::Number, k::Number) where {T}
+    x, y, z = A.tform([i, j, k]) #tformfwd(A.tform, i, j, k)
+    return A.data(x, y, z)
 end
 
-Base.similar(A::TransformedArray, ::Type{T}, dims::Dims) where T = Array{T}(dims)
+Base.similar(A::TransformedArray, ::Type{T}, dims::Dims) where {T} = Array{T}(dims)
 
 """
 `transform(A, tfm; origin_dest=center(A), origin_src=center(A)`
@@ -65,13 +65,13 @@ as `transform`, offset the origin of the transform used to construct
 origin_src - tform.linear*origin_dest
 ```
 """
-function transform(A::TransformedArray{T,N}; kwargs...) where {T,N}
+function transform(A::TransformedArray{T, N}; kwargs...) where {T, N}
     y = A.tform(ones(Int, N))
-    yt = (y...,)::NTuple{N,eltype(y)}
+    yt = (y...,)::NTuple{N, eltype(y)}
     a = A.data(yt...)
     dest = Array{typeof(a)}(undef, size(A))
     transform!(dest, A; kwargs...)
-    dest
+    return dest
 end
 
 transform(A, a::AffineMap; kwargs...) = transform(TransformedArray(A, a); kwargs...)
@@ -84,72 +84,79 @@ pre-allocated output array `dest`.
 If `src` is already a TransformedArray, use `transform!(dest, src;
 kwargs...)`.
 """
-function transform!(dest::AbstractArray{S,N},
-                    src::TransformedArray{T,N};
-                    origin_dest = center(dest),
-                    origin_src = center(src)) where {S,T,N}
+function transform!(
+        dest::AbstractArray{S, N},
+        src::TransformedArray{T, N};
+        origin_dest = center(dest),
+        origin_src = center(src)
+    ) where {S, T, N}
     tform = src.tform
     if tform.linear == Matrix{T}(I, N, N) && tform.translation == zeros(N) && size(dest) == size(src) && origin_dest == origin_src
         copyto!(dest, src)
         return dest
     end
-    offset = tform.translation - tform.linear*origin_dest + origin_src
-    _transform!(dest, src, offset)
+    offset = tform.translation - tform.linear * origin_dest + origin_src
+    return _transform!(dest, src, offset)
 end
 
 transform!(dest, src, a::AffineMap; kwargs...) = transform!(dest, TransformedArray(src, a); kwargs...)
 
-@require ImageMetadata="bc367c6b-8a6b-528e-b4bd-a4b897500b49" begin
+@require ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49" begin
     transform(A::ImageMetadata.ImageMeta, a::AffineMap; kwargs...) = ImageMetadata.copyproperties(A, transform(ImageMetadata.data(A), a; kwargs...))
     transform!(dest, A::ImageMetadata.ImageMeta, a::AffineMap; kwargs...) = ImageMetadata.copyproperties(A, transform!(dest, ImageMetadata.data(A), a; kwargs...))
 end
 
 # For a FilledExtrapolation, this is designed to (usually) avoid evaluating
 # the interpolation unless it is in-bounds.  This often improves performance.
-@generated function _transform!(dest::AbstractArray{S,N},
-                                src::TransformedArray{T,N,E},
-                                offset) where {S,T,N,E<:Interpolations.FilledExtrapolation}
+@generated function _transform!(
+        dest::AbstractArray{S, N},
+        src::TransformedArray{T, N, E},
+        offset
+    ) where {S, T, N, E <: Interpolations.FilledExtrapolation}
     # Initialize the final column of s "matrix," e.g., s_1_3 = A_1_3 + o_3
     # s stands for source-coordinates. The first "column," s_d_1, corresponds
     # to the actual interpolation position. The later columns simply cache
     # previous computations.
-    sN = ntuple(i->Expr(:(=), Symbol(string("s_",i,"_$N")), Expr(:call, :+, Symbol(string("A_",i,"_$N")), Symbol(string("o_",i)))), N)
-    quote
+    sN = ntuple(i -> Expr(:(=), Symbol(string("s_", i, "_$N")), Expr(:call, :+, Symbol(string("A_", i, "_$N")), Symbol(string("o_", i)))), N)
+    return quote
         tform = src.tform
         data = src.data
-        @nexprs $N d->(o_d = offset[d])
-        @nexprs $N j->(@nexprs $N i->(A_i_j = tform.linear[i,j]))
+        @nexprs $N d -> (o_d = offset[d])
+        @nexprs $N j -> (@nexprs $N i -> (A_i_j = tform.linear[i, j]))
         fill!(dest, data.fillvalue)
         $(sN...)
-        @nloops($N,i,d->(d>1 ? (1:size(dest,d)) : (imin:imax)),
-                # The pre-expression chooses the range within each column that will be in-bounds
-                d->(d >  2 ? (@nexprs $N e->s_e_{d-1}=A_e_{d-1}+s_e_d) :
+        @nloops(
+            $N, i, d -> (d > 1 ? (1:size(dest, d)) : (imin:imax)),
+            # The pre-expression chooses the range within each column that will be in-bounds
+            d -> (
+                d > 2 ? (@nexprs $N e -> s_e_{d - 1} = A_e_{d - 1} + s_e_d) :
                     d == 2 ? begin
                         imin = 1
-                        imax = size(dest,1)
-                        @nexprs $N e->((imin, imax) = irange(imin, imax, A_e_1, s_e_2, size(data, e)))
-                        @nexprs $N e->(s_e_1=A_e_1*imin+s_e_d)
+                        imax = size(dest, 1)
+                        @nexprs $N e -> ((imin, imax) = irange(imin, imax, A_e_1, s_e_2, size(data, e)))
+                        @nexprs $N e -> (s_e_1 = A_e_1 * imin + s_e_d)
                     end :
-                    nothing), # pre
-            d->(@nexprs $N e->(s_e_d += A_e_d)), # post
+                    nothing
+            ), # pre
+            d -> (@nexprs $N e -> (s_e_d += A_e_d)), # post
             # Perform the interpolation of the source data
-            @inbounds (@nref $N dest i) = (@ncall $N data d->s_d_1)
+            @inbounds (@nref $N dest i) = (@ncall $N data d -> s_d_1)
         )
         dest
     end
 end
 
-center(A::AbstractArray) = [(size(A,d)+1)/2 for d = 1:ndims(A)]
+center(A::AbstractArray) = [(size(A, d) + 1) / 2 for d in 1:ndims(A)]
 
 # Find i such that
 #      imin <= i <= imax
 #      1 <= coef*i+offset <= upper
 function irange(imin::Int, imax::Int, coef, offset, upper)
-    thresh = 10^4/typemax(Int)  # needed to avoid InexactError for results with abs() bigger than typemax
+    thresh = 10^4 / typemax(Int)  # needed to avoid InexactError for results with abs() bigger than typemax
     if coef > thresh
-        return max(imin, floor(Int, (1-offset)/coef)), min(imax, ceil(Int, (upper-offset)/coef))
+        return max(imin, floor(Int, (1 - offset) / coef)), min(imax, ceil(Int, (upper - offset) / coef))
     elseif coef < -thresh
-        return max(imin, floor(Int, (upper-offset)/coef)), min(imax, ceil(Int, (1-offset)/coef))
+        return max(imin, floor(Int, (upper - offset) / coef)), min(imax, ceil(Int, (1 - offset) / coef))
     else
         if 1 <= offset <= upper
             return imin, imax

--- a/src/timeseries.jl
+++ b/src/timeseries.jl
@@ -8,22 +8,22 @@ function tinterpolate(ϕsindex, tindex, nstack)
     ϕs = Vector{eltype(ϕsindex)}(undef, nstack)
     # Before the first tindex
     k = 0
-    for i in 1:tindex[1]-1
-        ϕs[k+=1] = ϕsindex[1]
+    for i in 1:(tindex[1] - 1)
+        ϕs[k += 1] = ϕsindex[1]
     end
     # Within tindex
     for i in 2:length(tindex)
-        ϕ1 = ϕsindex[i-1]
+        ϕ1 = ϕsindex[i - 1]
         ϕ2 = ϕsindex[i]
-        Δt = tindex[i] - tindex[i-1]
-        for j = 0:Δt-1
-            α = convert(eltype(eltype(ϕ1.u)), j/Δt)
-            ϕs[k+=1] = GridDeformation((1-α)*ϕ1.u + α*ϕ2.u, ϕ2.nodes)
+        Δt = tindex[i] - tindex[i - 1]
+        for j in 0:(Δt - 1)
+            α = convert(eltype(eltype(ϕ1.u)), j / Δt)
+            ϕs[k += 1] = GridDeformation((1 - α) * ϕ1.u + α * ϕ2.u, ϕ2.nodes)
         end
     end
     # After the last tindex
     for i in tindex[end]:nstack
-        ϕs[k+=1] = ϕsindex[end]
+        ϕs[k += 1] = ϕsindex[end]
     end
     return ϕs
 end
@@ -37,16 +37,16 @@ sudden (but persistent) shifts.
 
 See also [`tmedfilt!`](@ref).
 """
-function tmedfilt(ϕs::AbstractVector{D}, n) where D<:AbstractDeformation
-    nhalf = n>>1
-    2nhalf+1 == n || error("filter size must be odd")
+function tmedfilt(ϕs::AbstractVector{D}, n) where {D <: AbstractDeformation}
+    nhalf = n >> 1
+    2nhalf + 1 == n || error("filter size must be odd")
     T = eltype(eltype(D))
     v = Array{T}(undef, ndims(D), n)
-    vs = ntuple(d->view(v, d, :), ndims(D))
+    vs = ntuple(d -> view(v, d, :), ndims(D))
     ϕ1 = copy(ϕs[1])
     ϕout = Vector{typeof(ϕ1)}(undef, length(ϕs))
     ϕout[1] = ϕ1
-    _medfilt!(ϕout, ϕs, v, vs)  # function barrier due to instability of vs
+    return _medfilt!(ϕout, ϕs, v, vs)  # function barrier due to instability of vs
 end
 
 """
@@ -55,32 +55,32 @@ end
 In-place version of [`tmedfilt`](@ref). Writes the filtered deformations into the
 pre-allocated vector `out`, which must have the same length as `ϕs`.
 """
-function tmedfilt!(out::AbstractVector, ϕs::AbstractVector{D}, n) where D<:AbstractDeformation
-    nhalf = n>>1
-    2nhalf+1 == n || error("filter size must be odd")
+function tmedfilt!(out::AbstractVector, ϕs::AbstractVector{D}, n) where {D <: AbstractDeformation}
+    nhalf = n >> 1
+    2nhalf + 1 == n || error("filter size must be odd")
     length(out) == length(ϕs) || throw(DimensionMismatch("out and ϕs must have the same length"))
     T = eltype(eltype(D))
     v = Array{T}(undef, ndims(D), n)
-    vs = ntuple(d->view(v, d, :), ndims(D))
+    vs = ntuple(d -> view(v, d, :), ndims(D))
     out[1] = copy(ϕs[1])
-    _medfilt!(out, ϕs, v, vs)
+    return _medfilt!(out, ϕs, v, vs)
 end
 
-@noinline function _medfilt!(ϕout, ϕs, v, vs::NTuple{N,T}) where {N,T}
-    n = size(v,2)
-    nhalf = n>>1
+@noinline function _medfilt!(ϕout, ϕs, v, vs::NTuple{N, T}) where {N, T}
+    n = size(v, 2)
+    nhalf = n >> 1
     tmp = Vector{eltype(T)}(undef, N)
     u1 = ϕout[1].u
-    for i = 1+nhalf:length(ϕs)-nhalf
+    for i in (1 + nhalf):(length(ϕs) - nhalf)
         u = similar(u1)
         for I in eachindex(ϕs[i].u)
-            for j = -nhalf:nhalf
-                utmp = ϕs[i+j].u[I]
-                for d = 1:N
-                    v[d, j+nhalf+1] = utmp[d]
+            for j in -nhalf:nhalf
+                utmp = ϕs[i + j].u[I]
+                for d in 1:N
+                    v[d, j + nhalf + 1] = utmp[d]
                 end
             end
-            for d = 1:N
+            for d in 1:N
                 tmp[d] = median!(vs[d])
             end
             u[I] = tmp
@@ -88,11 +88,11 @@ end
         ϕout[i] = GridDeformation(u, ϕs[i].nodes)
     end
     # Copy the beginning and end
-    for i = 2:nhalf  # we did [1] in medfilt
+    for i in 2:nhalf  # we did [1] in medfilt
         ϕout[i] = copy(ϕs[i])
     end
-    for i = length(ϕs)-nhalf+1:length(ϕs)
+    for i in (length(ϕs) - nhalf + 1):length(ϕs)
         ϕout[i] = copy(ϕs[i])
     end
-    ϕout
+    return ϕout
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,45 +10,45 @@ centeraxes(axs) = map(centeraxis, axs)
 function centeraxis(ax)
     f, l = first(ax), last(ax)
     n = l - f + 1
-    nhalf = (n+1) ÷ 2
-    return 1-nhalf:n-nhalf
+    nhalf = (n + 1) ÷ 2
+    return (1 - nhalf):(n - nhalf)
 end
 
-function extract1(u::AbstractArray{V}, N, ssz) where V<:SVector
-    if ndims(u) == N+1
-        ϕ = GridDeformation(reshape(u, size(u)[1:end-1]), ssz)
+function extract1(u::AbstractArray{V}, N, ssz) where {V <: SVector}
+    if ndims(u) == N + 1
+        ϕ = GridDeformation(reshape(u, size(u)[1:(end - 1)]), ssz)
     else
         ϕ = GridDeformation(u, ssz)
     end
-    ϕ
+    return ϕ
 end
-extract1(ϕs::Vector{D}, N, ssz) where {D<:AbstractDeformation} = ϕs[1]
+extract1(ϕs::Vector{D}, N, ssz) where {D <: AbstractDeformation} = ϕs[1]
 
-function extracti(u::AbstractArray{V}, i, ssz) where V<:SVector
-    colons = [Colon() for d = 1:ndims(u)-1]
-    GridDeformation(u[colons..., i], ssz)
+function extracti(u::AbstractArray{V}, i, ssz) where {V <: SVector}
+    colons = [Colon() for d in 1:(ndims(u) - 1)]
+    return GridDeformation(u[colons..., i], ssz)
 end
-extracti(ϕs::Vector{D}, i, _) where {D<:AbstractDeformation} = ϕs[i]
+extracti(ϕs::Vector{D}, i, _) where {D <: AbstractDeformation} = ϕs[i]
 
-function checkϕdims(u::AbstractArray{V}, N, n) where V<:SVector
-    ndims(u) == N+1 || error("u's dimensionality $(ndims(u)) is inconsistent with the number of spatial dimensions $N of the image")
+function checkϕdims(u::AbstractArray{V}, N, n) where {V <: SVector}
+    ndims(u) == N + 1 || error("u's dimensionality $(ndims(u)) is inconsistent with the number of spatial dimensions $N of the image")
     if size(u)[end] != n
         error("Must have one `u` slice per image")
     end
-    nothing
+    return nothing
 end
-checkϕdims(ϕs::Vector{D}, N, n) where {D<:AbstractDeformation} = length(ϕs) == n || error("Must have one `ϕ` per image")
+checkϕdims(ϕs::Vector{D}, N, n) where {D <: AbstractDeformation} = length(ϕs) == n || error("Must have one `ϕ` per image")
 
 
 # TODO?: do we need to return real values beyond-the-edge for a SubArray?
 
-floattype(::Type{T}) where T<:AbstractFloat = T
+floattype(::Type{T}) where {T <: AbstractFloat} = T
 floattype(::Type{<:Integer}) = Float64
-floattype(::Type{SVector{N,T}}) where {N,T} = floattype(T)
+floattype(::Type{SVector{N, T}}) where {N, T} = floattype(T)
 
-nanvalue(::Type{T}) where T<:Real = convert(promote_type(T, Float32), NaN)
-nanvalue(::Type{C}) where C<:AbstractGray = Gray(nanvalue(eltype(C)))
-nanvalue(::Type{C}) where C<:AbstractRGB  = (x = nanvalue(eltype(C)); RGB(x, x, x))
+nanvalue(::Type{T}) where {T <: Real} = convert(promote_type(T, Float32), NaN)
+nanvalue(::Type{C}) where {C <: AbstractGray} = Gray(nanvalue(eltype(C)))
+nanvalue(::Type{C}) where {C <: AbstractRGB} = (x = nanvalue(eltype(C)); RGB(x, x, x))
 
 to_etp(img) = extrapolate(interpolate(img, BSpline(Linear())), nanvalue(eltype(img)))
 
@@ -64,66 +64,66 @@ getcoefs(itp::Interpolations.BSplineInterpolation) = itp.coefs
 getcoefs(u::AbstractArray{<:SVector}) = u
 
 # Extensions to Interpolations and StaticArrays
-@generated function vecindex(A::AbstractArray, x::SVector{N}) where N
-    args = [:(x[$d]) for d = 1:N]
+@generated function vecindex(A::AbstractArray, x::SVector{N}) where {N}
+    args = [:(x[$d]) for d in 1:N]
     meta = Expr(:meta, :inline)
-    quote
+    return quote
         $meta
         getindex(A, $(args...))
     end
 end
 
-@generated function vecindex(A::AbstractInterpolation, x::SVector{N}) where N
-    args = [:(x[$d]) for d = 1:N]
+@generated function vecindex(A::AbstractInterpolation, x::SVector{N}) where {N}
+    args = [:(x[$d]) for d in 1:N]
     meta = Expr(:meta, :inline)
-    quote
+    return quote
         $meta
         A($(args...))
     end
 end
 
-@generated function vecgradient!(g, itp::AbstractArray, x::SVector{N}) where N
-    args = [:(x[$d]) for d = 1:N]
+@generated function vecgradient!(g, itp::AbstractArray, x::SVector{N}) where {N}
+    args = [:(x[$d]) for d in 1:N]
     meta = Expr(:meta, :inline)
-    quote
+    return quote
         $meta
         Interpolations.gradient!(g, itp, $(args...))
     end
 end
 
-function convert_to_fixed(u::Array{T}, sz=size(u)) where T
+function convert_to_fixed(u::Array{T}, sz = size(u)) where {T}
     N = sz[1]
-    convert_to_fixed(SVector{N, T}, u, tail(sz))
+    return convert_to_fixed(SVector{N, T}, u, tail(sz))
 end
 
 # Unlike the one above, this is type-stable
-function convert_to_fixed(::Type{SVector{N,T}}, u::AbstractArray{T}, sz=tail(size(u))) where {T,N}
-    reshape(reinterpret(SVector{N,T}, vec(u)), sz)
+function convert_to_fixed(::Type{SVector{N, T}}, u::AbstractArray{T}, sz = tail(size(u))) where {T, N}
+    return reshape(reinterpret(SVector{N, T}, vec(u)), sz)
 end
 
-@generated function copy_ctf!(dest::Array{SVector{N,T}}, src::Array) where {N,T}
-    exvec = [:(src[offset+$d]) for d=1:N]
-    quote
-        for i = 1:length(dest)
-            offset = (i-1)*N
+@generated function copy_ctf!(dest::Array{SVector{N, T}}, src::Array) where {N, T}
+    exvec = [:(src[offset + $d]) for d in 1:N]
+    return quote
+        for i in 1:length(dest)
+            offset = (i - 1) * N
             dest[i] = SVector($(exvec...))
         end
         dest
     end
 end
 
-function convert_from_fixed(uf::AbstractArray{SVector{N,T}}, sz=size(uf)) where {N,T}
+function convert_from_fixed(uf::AbstractArray{SVector{N, T}}, sz = size(uf)) where {N, T}
     if isbitstype(T) && isa(uf, Array)
         u = reshape(reinterpret(T, vec(uf)), (N, sz...))
     else
         u = Array{T}(undef, N, sz...)
-        for i = 1:length(uf)
-            for d = 1:N
-                u[d,i] = uf[i][d]
+        for i in 1:length(uf)
+            for d in 1:N
+                u[d, i] = uf[i][d]
             end
         end
     end
-    u
+    return u
 end
 
 # # Note this is a bit unsafe as it requires the user to specify C correctly
@@ -133,8 +133,8 @@ end
 # end
 
 # Wrapping functions to interface with CoordinateTransfromations instead of AffineTransfroms module
-tformeye(m::Int) = AffineMap(Matrix{Float64}(I,m,m), zeros(m))
-tformtranslate(trans::AbstractVector) = (m = length(trans); AffineMap(Matrix{Float64}(I,m,m), trans))
+tformeye(m::Int) = AffineMap(Matrix{Float64}(I, m, m), zeros(m))
+tformtranslate(trans::AbstractVector) = (m = length(trans); AffineMap(Matrix{Float64}(I, m, m), trans))
 
 """
     rotation2(angle) -> RotMatrix
@@ -145,16 +145,16 @@ Construct a 2D rotation matrix from `angle` (in radians). Returns a `RotMatrix`
 rotation2(angle) = RotMatrix(angle)
 function tformrotate(angle)
     A = RotMatrix(angle)
-    AffineMap(A, zeros(eltype(A),2))
+    return AffineMap(A, zeros(eltype(A), 2))
 end
 
 function rotationparameters(R::AbstractMatrix)
     size(R, 1) == size(R, 2) || error("Matrix must be square")
     if size(R, 1) == 2
-        return [atan(-R[1,2],R[1,1])]
+        return [atan(-R[1, 2], R[1, 1])]
     elseif size(R, 1) == 3
         aa = AngleAxis(R)
-        return rotation_angle(aa)*rotation_axis(aa)
+        return rotation_angle(aa) * rotation_axis(aa)
     else
         error("Rotations in $(size(R, 1)) dimensions not supported")
     end
@@ -171,22 +171,22 @@ The two-argument form uses `axis` (a 3-vector) and `angle` (in radians).
 The one-argument form treats `norm(axis)` as the angle and `axis/norm(axis)` as the axis
 (angle-axis representation where the angle is encoded in the magnitude).
 """
-function rotation3(axis::AbstractVector{T}, angle) where T
+function rotation3(axis::AbstractVector{T}, angle) where {T}
     n = norm(axis)
-    axisn = n>0 ? axis/n : (tmp = zeros(T,length(axis)); tmp[1] = 1; tmp)
-    AngleAxis(angle, axisn...)
+    axisn = n > 0 ? axis / n : (tmp = zeros(T, length(axis)); tmp[1] = 1; tmp)
+    return AngleAxis(angle, axisn...)
 end
 
-function rotation3(axis::AbstractVector{T}) where T
+function rotation3(axis::AbstractVector{T}) where {T}
     n = norm(axis)
-    axisn = n>0 ? axis/n : (tmp = zeros(typeof(one(T)/1),length(axis)); tmp[1] = 1; tmp)
-    AngleAxis(n, axisn...)
+    axisn = n > 0 ? axis / n : (tmp = zeros(typeof(one(T) / 1), length(axis)); tmp[1] = 1; tmp)
+    return AngleAxis(n, axisn...)
 end
 
 
 function tformrotate(axis::AbstractVector, angle)
     if length(axis) == 3
-        return AffineMap(rotation3(axis, angle), zeros(eltype(axis),3))
+        return AffineMap(rotation3(axis, angle), zeros(eltype(axis), 3))
     else
         error("Dimensionality ", length(axis), " not supported")
     end
@@ -194,7 +194,7 @@ end
 
 function tformrotate(x::AbstractVector)
     if length(x) == 3
-        return AffineMap(rotation3(x), zeros(eltype(x),3))
+        return AffineMap(rotation3(x), zeros(eltype(x), 3))
     else
         error("Dimensionality ", length(x), " not supported")
     end

--- a/src/visualize.jl
+++ b/src/visualize.jl
@@ -17,17 +17,17 @@ Optionally specify the element type `T` of `img`.
 
 See also [`warpgrid`](@ref).
 """
-function nodegrid(::Type{T}, nodes::NTuple{N,AbstractRange}) where {T,N}
-    @assert all(r->first(r)==1, nodes)
-    inds = map(r->Base.OneTo(ceil(Int, last(r))), nodes)
+function nodegrid(::Type{T}, nodes::NTuple{N, AbstractRange}) where {T, N}
+    @assert all(r -> first(r) == 1, nodes)
+    inds = map(r -> Base.OneTo(ceil(Int, last(r))), nodes)
     img = Array{T}(undef, map(length, inds))
     fill!(img, zero(T))
-    for idim = 1:N
+    for idim in 1:N
         indexes = Any[inds...]
-        indexes[idim] = map(x->clamp(round(Int, x), first(inds[idim])+1, last(inds[idim])-1), nodes[idim])
+        indexes[idim] = map(x -> clamp(round(Int, x), first(inds[idim]) + 1, last(inds[idim]) - 1), nodes[idim])
         img[indexes...] .= one(T)
     end
-    img
+    return img
 end
 nodegrid(::Type{T}, ϕ::GridDeformation) where {T} = nodegrid(T, ϕ.nodes)
 nodegrid(arg) = nodegrid(Bool, arg)
@@ -49,15 +49,15 @@ that has the warped grid in magenta and the original grid in green.
 
 See also [`nodegrid`](@ref).
 """
-function warpgrid(ϕ::AbstractDeformation; scale=1, showidentity::Bool=false)
+function warpgrid(ϕ::AbstractDeformation; scale = 1, showidentity::Bool = false)
     img = nodegrid(ϕ)
     if scale != 1
-        ϕ = GridDeformation(scale*ϕ.u, ϕ.nodes)
+        ϕ = GridDeformation(scale * ϕ.u, ϕ.nodes)
     end
     wimg = warp(img, ϕ)
     if showidentity
-        n = ndims(img)+1
-        return reshape(reinterpret(RGB{Float32}, permutedims(cat(wimg, img, wimg, dims=n), (n,1:ndims(img)...))),(size(img)...,))
+        n = ndims(img) + 1
+        return reshape(reinterpret(RGB{Float32}, permutedims(cat(wimg, img, wimg, dims = n), (n, 1:ndims(img)...))), (size(img)...,))
     end
-    wimg
+    return wimg
 end

--- a/src/warp.jl
+++ b/src/warp.jl
@@ -1,4 +1,3 @@
-
 """
 `wimg = warp(img, ϕ)` warps the array `img` according to the
 deformation `ϕ`.
@@ -6,19 +5,19 @@ deformation `ϕ`.
 function warp(img::AbstractArray, ϕ::AbstractDeformation)
     wimg = WarpedArray(img, ϕ)
     dest = similar(img, warp_type(img))
-    warp!(dest, wimg)
+    return warp!(dest, wimg)
 end
 
-warp_type(img::AbstractArray{T}) where {T<:AbstractFloat} = T
-warp_type(img::AbstractArray{T}) where {T<:Number} = Float32
-warp_type(img::AbstractArray{C}) where {C<:Colorant} = warp_type(img, eltype(eltype(C)))
-warp_type(img::AbstractArray{C}, ::Type{T}) where {C<:Colorant, T<:AbstractFloat} = C
-warp_type(img::AbstractArray{C}, ::Type{T}) where {C<:Colorant, T} = base_colorant_type(C){Float32}
+warp_type(img::AbstractArray{T}) where {T <: AbstractFloat} = T
+warp_type(img::AbstractArray{T}) where {T <: Number} = Float32
+warp_type(img::AbstractArray{C}) where {C <: Colorant} = warp_type(img, eltype(eltype(C)))
+warp_type(img::AbstractArray{C}, ::Type{T}) where {C <: Colorant, T <: AbstractFloat} = C
+warp_type(img::AbstractArray{C}, ::Type{T}) where {C <: Colorant, T} = base_colorant_type(C){Float32}
 
 """
 `warp!(dest, src::WarpedArray)` instantiates a `WarpedArray` in the output `dest`.
 """
-function warp!(dest::AbstractArray{T,N}, src::WarpedArray) where {T,N}
+function warp!(dest::AbstractArray{T, N}, src::WarpedArray) where {T, N}
     axes(dest) == axes(src) || throw(DimensionMismatch("dest must have the same axes as src"))
     destiter = CartesianIndices(axes(dest))
     I, deststate = iterate(destiter)
@@ -38,7 +37,7 @@ result is stored in `dest`.
 """
 function warp!(dest::AbstractArray, img::AbstractArray, ϕ::AbstractDeformation)
     wimg = WarpedArray(to_etp(img), ϕ)
-    warp!(dest, wimg)
+    return warp!(dest, wimg)
 end
 
 """
@@ -46,7 +45,7 @@ end
 """
 function warp!(dest::AbstractArray, img::AbstractArray, A::AffineMap, ϕ::AbstractDeformation)
     wimg = WarpedArray(to_etp(img, A), ϕ)
-    warp!(dest, wimg)
+    return warp!(dest, wimg)
 end
 
 """
@@ -63,7 +62,7 @@ An alternative syntax is `warp!(io, img, uarray; [eltype=Float32, nworkers=1])`,
 where `uarray` is an array of `u` values with `size(uarray)[end] ==
 nimages(img)`.
 """
-function warp!(dest::Union{IO,HDF5.Dataset,JLD2.JLDFile}, img, ϕs; eltype::Type=Float32, nworkers=1)
+function warp!(dest::Union{IO, HDF5.Dataset, JLD2.JLDFile}, img, ϕs; eltype::Type = Float32, nworkers = 1)
     T = eltype
     n = nimages(img)
     saxs = indices_spatial(img)
@@ -80,21 +79,21 @@ function warp!(dest::Union{IO,HDF5.Dataset,JLD2.JLDFile}, img, ϕs; eltype::Type
         return _warp!(T, dest, img, ϕs, nworkers)
     end
     destarray = Array{T}(undef, ssz)
-    @showprogress dt=1 desc="Stacks:" for i = 1:n
+    @showprogress dt = 1 desc = "Stacks:" for i in 1:n
         ϕ = extracti(ϕs, i, saxs)
         warp!(destarray, view(img, timeaxis(img)(i)), ϕ)
         warp_write(dest, destarray, i)
     end
-    nothing
+    return nothing
 end
 
-warp!(dest::Union{IO,HDF5.Dataset,JLD2.JLDFile}, img, u::AbstractArray{<:Real}; kwargs...) =
+warp!(dest::Union{IO, HDF5.Dataset, JLD2.JLDFile}, img, u::AbstractArray{<:Real}; kwargs...) =
     warp!(dest, img, Array(convert_to_fixed(u)); kwargs...)
 
-warp!(dest::Union{HDF5.Dataset,JLD2.JLDFile}, img, u; nworkers=1) =
-    warp!(dest, img, u; eltype=Base.eltype(dest), nworkers)
+warp!(dest::Union{HDF5.Dataset, JLD2.JLDFile}, img, u; nworkers = 1) =
+    warp!(dest, img, u; eltype = Base.eltype(dest), nworkers)
 
-function _warp!(::Type{T}, dest, img, ϕs, nworkers) where T
+function _warp!(::Type{T}, dest, img, ϕs, nworkers) where {T}
     n = nimages(img)
     saxs = indices_spatial(img)
     ssz = map(length, saxs)
@@ -103,21 +102,21 @@ function _warp!(::Type{T}, dest, img, ϕs, nworkers) where T
     swarped = Vector{Any}()
     rrs = Vector{RemoteChannel}()
     mydir = splitdir(@__FILE__)[1]
-    pkgbase = String(chop(mydir,tail=4))
+    pkgbase = String(chop(mydir, tail = 4))
     for p in wpids
         remotecall_fetch(Main.eval, p, :(using Pkg))
         remotecall_fetch(Main.eval, p, :(Pkg.activate($pkgbase)))
         remotecall_fetch(Main.eval, p, :(push!(LOAD_PATH, $mydir)))
         remotecall_fetch(Main.eval, p, :(using RegisterDeformation))
-        push!(simg, SharedArray{eltype(img)}(ssz, pids=[myid(),p]))
-        push!(swarped, SharedArray{T}(ssz, pids=[myid(),p]))
+        push!(simg, SharedArray{eltype(img)}(ssz, pids = [myid(), p]))
+        push!(swarped, SharedArray{T}(ssz, pids = [myid(), p]))
     end
     nextidx = 0
     getnextidx() = nextidx += 1
     writing_mutex = RemoteChannel()
-    prog = Progress(n; dt=1, desc="Stacks:")
+    prog = Progress(n; dt = 1, desc = "Stacks:")
     @sync begin
-        for i = 1:nworkers
+        for i in 1:nworkers
             p = wpids[i]
             src = simg[i]
             warped = swarped[i]
@@ -135,18 +134,18 @@ function _warp!(::Type{T}, dest, img, ϕs, nworkers) where T
         end
     end
     finish!(prog)
-    nothing
+    return nothing
 end
 
 warp_write(io::IO, destarray) = write(io, destarray)
 function warp_write(io::IO, destarray, i)
-    offset = (i-1)*length(destarray)*sizeof(eltype(destarray))
+    offset = (i - 1) * length(destarray) * sizeof(eltype(destarray))
     seek(io, offset)
-    write(io, destarray)
+    return write(io, destarray)
 end
 function warp_write(dest, destarray, i)
-    colons = [Colon() for d = 1:ndims(destarray)]
-    dest[colons..., i] = destarray
+    colons = [Colon() for d in 1:ndims(destarray)]
+    return dest[colons..., i] = destarray
 end
 
 """
@@ -161,6 +160,6 @@ of `A`.
 function translate(A::AbstractArray, displacement::Union{AbstractVector{<:Integer}, Dims})
     disp = zeros(Int, ndims(A))
     disp[[coords_spatial(A)...]] = displacement
-    indx = UnitRange{Int}[ axes(A, i) .+ disp[i] for i = 1:ndims(A) ]
-    get(A, indx, NaN)
+    indx = UnitRange{Int}[ axes(A, i) .+ disp[i] for i in 1:ndims(A) ]
+    return get(A, indx, NaN)
 end

--- a/src/warpedarray.jl
+++ b/src/warpedarray.jl
@@ -16,22 +16,24 @@ where
   evaluated anywhere.  See the Interpolations package.
 - ϕ is an `AbstractDeformation`
 """
-struct WarpedArray{T,N,A<:Extrapolatable,D<:AbstractDeformation} <: AbstractArray{T,N}
+struct WarpedArray{T, N, A <: Extrapolatable, D <: AbstractDeformation} <: AbstractArray{T, N}
     data::A
     ϕ::D
 end
 
 # User already supplied an interpolatable ϕ
-function WarpedArray(data::Extrapolatable{T,N},
-                     ϕ::GridDeformation{S,N,A}) where {T,N,S,A<:AbstractInterpolation}
-    WarpedArray{T,N,typeof(data),typeof(ϕ)}(data, ϕ)
+function WarpedArray(
+        data::Extrapolatable{T, N},
+        ϕ::GridDeformation{S, N, A}
+    ) where {T, N, S, A <: AbstractInterpolation}
+    return WarpedArray{T, N, typeof(data), typeof(ϕ)}(data, ϕ)
 end
 
 # Create an interpolatable ϕ
-function WarpedArray(data::Extrapolatable{T,N}, ϕ::GridDeformation) where {T,N}
+function WarpedArray(data::Extrapolatable{T, N}, ϕ::GridDeformation) where {T, N}
     itp = scale(interpolate(ϕ.u, BSpline(Quadratic(Flat(OnCell())))), ϕ.nodes...)
     ϕ′ = GridDeformation(itp, ϕ.nodes)
-    WarpedArray{T,N,typeof(data),typeof(ϕ′)}(data, ϕ′)
+    return WarpedArray{T, N, typeof(data), typeof(ϕ′)}(data, ϕ′)
 end
 
 WarpedArray(data, ϕ::GridDeformation) = WarpedArray(to_etp(data), ϕ)
@@ -42,10 +44,10 @@ Base.size(A::WarpedArray, i::Integer) = size(A.data, i)
 Base.axes(A::WarpedArray) = axes(A.data)
 Base.axes(A::WarpedArray, i::Integer) = axes(A.data, i)
 
-@inline function Base.getindex(W::WarpedArray{T,N}, I::Vararg{Number,N}) where {T,N}
+@inline function Base.getindex(W::WarpedArray{T, N}, I::Vararg{Number, N}) where {T, N}
     ϕx = W.ϕ(I...)
     return W.data(ϕx...)
 end
 
-ImageAxes.getindex!(dest, W::WarpedArray{T,N}, coords::Vararg{Any,N}) where {T,N} =
+ImageAxes.getindex!(dest, W::WarpedArray{T, N}, coords::Vararg{Any, N}) where {T, N} =
     Base._unsafe_getindex!(dest, W, coords...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,10 +11,10 @@ using JLD2, HDF5, FileIO
 using ImageFiltering
 
 @testset "Nodes" begin
-    nodes = (range(1, stop=15, length=5), range(1, stop=11, length=3))
-    @test arraysize(nodes) == (15,11)
+    nodes = (range(1, stop = 15, length = 5), range(1, stop = 11, length = 3))
+    @test arraysize(nodes) == (15, 11)
 
-    nodesall = (nodes[1].*ones(length(nodes[2]))', ones(length(nodes[1])).*nodes[2]')
+    nodesall = (nodes[1] .* ones(length(nodes[2]))', ones(length(nodes[1])) .* nodes[2]')
     for (i, knt) in enumerate(eachnode(nodes))
         @test knt[1] == nodesall[1][i]
         @test knt[2] == nodesall[2][i]
@@ -22,7 +22,7 @@ using ImageFiltering
 end
 
 @testset "Interpolation and extrapolation" begin
-    nodes = (range(1, stop=15, length=5), range(1, stop=11, length=3))
+    nodes = (range(1, stop = 15, length = 5), range(1, stop = 11, length = 3))
     u = randn(length(nodes), map(length, nodes)...)
     ϕ = GridDeformation(u, nodes)
     ϕi = interpolate(ϕ)
@@ -35,50 +35,52 @@ end
 end
 
 @testset "Deformation tests" begin
-    randrange(xmin, xmax) = (xmax-xmin)*rand() + xmin
+    randrange(xmin, xmax) = (xmax - xmin) * rand() + xmin
 
     ## Deformations
-    for nodes in ((range(1, stop=15, length=5),),
-                  (range(1, stop=15, length=5), range(1, stop=8, length=4)),
-                  (range(1, stop=15, length=3), range(1, stop=8, length=4), range(1, stop=7, length=2)),
-                  (range(1, stop=15, length=5), range(1, stop=8, length=4), range(1, stop=7, length=6)))
+    for nodes in (
+            (range(1, stop = 15, length = 5),),
+            (range(1, stop = 15, length = 5), range(1, stop = 8, length = 4)),
+            (range(1, stop = 15, length = 3), range(1, stop = 8, length = 4), range(1, stop = 7, length = 2)),
+            (range(1, stop = 15, length = 5), range(1, stop = 8, length = 4), range(1, stop = 7, length = 6)),
+        )
         sz = map(length, nodes)
-        rng = map(z->convert(Int, maximum(z)), nodes)
+        rng = map(z -> convert(Int, maximum(z)), nodes)
         # Zero deformation
         u = zeros(length(nodes), sz...)
         ϕ = interpolate(GridDeformation(u, nodes))
-        for i = 1:10
-            x = map(z->rand(1:z), rng)
+        for i in 1:10
+            x = map(z -> rand(1:z), rng)
             @test @inferred(ϕ(x...)) ≈ [x...]
-            if all(x->x>2, sz)
-                y = map(z->rand(2:z-1)+rand()-0.5, rng)
+            if all(x -> x > 2, sz)
+                y = map(z -> rand(2:(z - 1)) + rand() - 0.5, rng)
                 @test ϕ(y...) ≈ [y...]
             end
         end
         # Constant shift
         dx = randn(length(nodes))
-        u = zeros(length(nodes), sz...).+dx
+        u = zeros(length(nodes), sz...) .+ dx
         ϕ = interpolate(GridDeformation(u, nodes))
-        for i = 1:10
-            x = map(z->rand(1:z), rng)
-            @test ϕ(x...) ≈ [x...]+dx
-            if all(x->x>2, sz)
-                y = map(z->rand(2:z-1)+rand()-0.5, rng)
-                @test ϕ(y...) ≈ [y...]+dx
+        for i in 1:10
+            x = map(z -> rand(1:z), rng)
+            @test ϕ(x...) ≈ [x...] + dx
+            if all(x -> x > 2, sz)
+                y = map(z -> rand(2:(z - 1)) + rand() - 0.5, rng)
+                @test ϕ(y...) ≈ [y...] + dx
             end
         end
         # "Biquadratic"
-        if all(x->x>2, sz)
+        if all(x -> x > 2, sz)
             N = length(nodes)
             u_is = Vector{Any}(undef, N)
             fs = Vector{Any}(undef, N)
             R = CartesianIndices(sz)
-            for i = 1:N
-                let cntr = Float64[rand(1:z-1)+rand() for z in rng], q = rand(N)
-                    f = x -> dot(q, (x-cntr).^2)
+            for i in 1:N
+                let cntr = Float64[rand(1:(z - 1)) + rand() for z in rng], q = rand(N)
+                    f = x -> dot(q, (x - cntr) .^ 2)
                     ui = zeros(sz)
                     for I in R
-                        ui[I] = f(Float64[nodes[d][I[d]] for d = 1:N])
+                        ui[I] = f(Float64[nodes[d][I[d]] for d in 1:N])
                     end
                     u_is[i] = reshape(ui, 1, sz...)
                     fs[i] = f
@@ -86,15 +88,15 @@ end
             end
             u = cat(u_is..., dims = 1)
             ϕ = interpolate!(GridDeformation(copy(u), nodes), InPlaceQ(OnCell()))
-            for i = 1:10
-                y = Float64[randrange((node[2]+node[1])/2, (node[end]+node[end-1])/2) for node in nodes]
-                dx = Float64[fs[d](y) for d=1:N]
+            for i in 1:10
+                y = Float64[randrange((node[2] + node[1]) / 2, (node[end] + node[end - 1]) / 2) for node in nodes]
+                dx = Float64[fs[d](y) for d in 1:N]
                 try
-                    @test ϕ(y...) ≈ y + Float64[fs[d](y) for d=1:N]
+                    @test ϕ(y...) ≈ y + Float64[fs[d](y) for d in 1:N]
                 catch err
                     @show y nodes
-                    @show [((node[2]+node[1])/2, (node[end]+node[end-1])/2) for node in nodes]
-                    @show Float64[fs[d](y) for d=1:N]
+                    @show [((node[2] + node[1]) / 2, (node[end] + node[end - 1]) / 2) for node in nodes]
+                    @show Float64[fs[d](y) for d in 1:N]
                     rethrow(err)
                 end
             end
@@ -103,13 +105,13 @@ end
 end
 
 @testset "tform2deformation" begin
-    s = [3.3,-2.6]
-    gsize = (3,2)
+    s = [3.3, -2.6]
+    gsize = (3, 2)
     A = tformtranslate(s)
-    ϕ = tform2deformation(A, map(Base.OneTo, (500,480)), gsize)
-    u = reshape(reinterpret(Float64, ϕ.u), tuple(2,gsize...))
-    @test all(u[1,:,:] .== s[1])
-    @test all(u[2,:,:] .== s[2])
+    ϕ = tform2deformation(A, map(Base.OneTo, (500, 480)), gsize)
+    u = reshape(reinterpret(Float64, ϕ.u), tuple(2, gsize...))
+    @test all(u[1, :, :] .== s[1])
+    @test all(u[2, :, :] .== s[2])
 end
 
 @testset "similar_deformation" begin
@@ -119,77 +121,77 @@ end
     unew = [0.7, 0.4, -0.33]
     ϕnew = similar_deformation(ϕref, unew)
     ϕi = interpolate!(copy(ϕnew))
-    @test ϕi.u(0)  ≈ SVector(0.7)
-    @test ϕi.u(5)  ≈ SVector(0.4)
+    @test ϕi.u(0) ≈ SVector(0.7)
+    @test ϕi.u(5) ≈ SVector(0.4)
     @test ϕi.u(10) ≈ SVector(-0.33)
 
     ucoefs = copy(ϕi.u.itp.coefs)
     ϕiref = interpolate!(copy(ϕref))
     ϕi = similar_deformation(ϕiref, ucoefs)
-    @test ϕi.u(0)  ≈ SVector(0.7)
-    @test ϕi.u(5)  ≈ SVector(0.4)
+    @test ϕi.u(0) ≈ SVector(0.7)
+    @test ϕi.u(5) ≈ SVector(0.4)
     @test ϕi.u(10) ≈ SVector(-0.33)
 end
 
 @testset "warp" begin
     # Ensure there is no conflict between ImageTransformations and RegisterDeformation
-    tform = tformrotate(pi/4)
+    tform = tformrotate(pi / 4)
     ramp = 0.0:0.01:1
     nhalf = length(ramp) ÷ 2
-    for img in (ramp*ramp', OffsetArray(ramp*ramp', -nhalf:nhalf, -nhalf:nhalf))
+    for img in (ramp * ramp', OffsetArray(ramp * ramp', -nhalf:nhalf, -nhalf:nhalf))
         imgw1 = warp(img, tform, axes(img))
         ϕ = tform2deformation(tform, axes(img), (7, 7))
         imgw2 = warp(img, ϕ)
-        @test all(x->isnan(x) || abs(x) < 0.02, imgw1 - imgw2)
+        @test all(x -> isnan(x) || abs(x) < 0.02, imgw1 - imgw2)
     end
 end
 
 @testset "WarpedArray" begin
     znan(x) = isnan(x) ? zero(x) : x
 
-    p = (1:100).-5
+    p = (1:100) .- 5
 
     dest = Vector{Float32}(undef, 10)
 
     # Simple translations in 1d
-    ϕ = GridDeformation([0.0,0.0]', axes(p))
-    q = WarpedArray(p, ϕ);
+    ϕ = GridDeformation([0.0, 0.0]', axes(p))
+    q = WarpedArray(p, ϕ)
     getindex!(dest, q, 1:10)
-    @test maximum(abs.(dest - p[1:10])) < 10*eps(maximum(abs.(dest)))
+    @test maximum(abs.(dest - p[1:10])) < 10 * eps(maximum(abs.(dest)))
 
-    ϕ = GridDeformation([1.0,1.0]', axes(p))
-    q = WarpedArray(p, ϕ);
+    ϕ = GridDeformation([1.0, 1.0]', axes(p))
+    q = WarpedArray(p, ϕ)
     getindex!(dest, q, 1:10)
-    @test maximum(abs.(dest - p[2:11])) < 10*eps(maximum(abs.(dest)))
+    @test maximum(abs.(dest - p[2:11])) < 10 * eps(maximum(abs.(dest)))
 
-    ϕ = GridDeformation([-2.0,-2.0]', axes(p))
-    q = WarpedArray(p, ϕ);
+    ϕ = GridDeformation([-2.0, -2.0]', axes(p))
+    q = WarpedArray(p, ϕ)
     getindex!(dest, q, 1:10)
-    @test maximum(abs.(dest[3:end] - p[1:8])) < 10*eps(maximum(abs.(dest[3:end])))
+    @test maximum(abs.(dest[3:end] - p[1:8])) < 10 * eps(maximum(abs.(dest[3:end])))
 
     getindex!(dest, q, 3:12)
-    @test maximum(abs.(dest - p[1:10])) < 10*eps(maximum(abs.(dest)))
+    @test maximum(abs.(dest - p[1:10])) < 10 * eps(maximum(abs.(dest)))
 
-    ϕ = GridDeformation([2.0,2.0]', axes(p))
-    q = WarpedArray(p, ϕ);
+    ϕ = GridDeformation([2.0, 2.0]', axes(p))
+    q = WarpedArray(p, ϕ)
     getindex!(dest, q, 1:10)
-    @test maximum(abs.(dest - p[3:12])) < 10*eps(maximum(abs.(dest)))
+    @test maximum(abs.(dest - p[3:12])) < 10 * eps(maximum(abs.(dest)))
 
-    ϕ = GridDeformation([5.0,5.0]', axes(p))
-    q = WarpedArray(p, ϕ);
+    ϕ = GridDeformation([5.0, 5.0]', axes(p))
+    q = WarpedArray(p, ϕ)
     getindex!(dest, q, 1:10)
-    @test maximum(abs.(dest - p[6:15])) < 10*eps(maximum(abs.(dest)))
+    @test maximum(abs.(dest - p[6:15])) < 10 * eps(maximum(abs.(dest)))
 
     # SubArray (test whether we can go beyond edges)
     psub = view(collect(p), 3:20)
-    ϕ = GridDeformation([0.0,0.0]', axes(p))
-    q = WarpedArray(psub, ϕ);
+    ϕ = GridDeformation([0.0, 0.0]', axes(p))
+    q = WarpedArray(psub, ϕ)
     getindex!(dest, q, -1:8)
-    @test maximum(abs.(dest[3:end] - p[3:10])) < 10*eps(maximum(abs.(dest[3:end])))
+    @test maximum(abs.(dest[3:end] - p[3:10])) < 10 * eps(maximum(abs.(dest[3:end])))
     any(isnan, dest) && @warn("Some dest are NaN, not yet sure whether this is a problem")
 
     # Stretches
-    u = [0.0,5.0,10.0]
+    u = [0.0, 5.0, 10.0]
     ϕ = interpolate(GridDeformation(u', axes(p)), Line(OnCell()))
     q = WarpedArray(p, ϕ)
     getindex!(dest, q, 1:10)
@@ -197,43 +199,43 @@ end
     getindex!(dest, q, 86:95)
     @test isnan.(dest) == [falses(5);trues(5)]  # fixme
     dest2 = getindex!(zeros(Float32, 100), q, 1:100)
-    @test all(abs.(diff(dest2)[26:74] .- ((u[3]-u[1])/99+1)) .< sqrt(eps(1.0f0)))
+    @test all(abs.(diff(dest2)[26:74] .- ((u[3] - u[1]) / 99 + 1)) .< sqrt(eps(1.0f0)))
 
     #2d
     p = reshape(1:120, 10, 12)
     u1 = [2.0 2.0; 2.0 2.0]
     u2 = [-1.0 -1.0; -1.0 -1.0]
-    ϕ = GridDeformation((u1,u2), axes(p))
+    ϕ = GridDeformation((u1, u2), axes(p))
     q = WarpedArray(p, ϕ)
     dest = zeros(axes(p))
-    rng = (1:size(p,1),1:size(p,2))
+    rng = (1:size(p, 1), 1:size(p, 2))
     getindex!(dest, q, rng...)
-    @test maximum(abs.(znan.(dest[1:7,2:end] - p[3:9,1:end-1]))) < 10*eps(maximum(znan.(dest)))
+    @test maximum(abs.(znan.(dest[1:7, 2:end] - p[3:9, 1:(end - 1)]))) < 10 * eps(maximum(znan.(dest)))
 end
 
 @testset "Composition" begin
     # Test that two rotations approximately compose to another rotation
-    gridsize = (49,47)
-    imgaxs = centeraxes(map(Base.OneTo, (200,200)))
-    ϕ1 = tform2deformation(tformrotate( pi/180), imgaxs, gridsize)
-    ϕ2 = tform2deformation(tformrotate(2pi/180), imgaxs, gridsize)
+    gridsize = (49, 47)
+    imgaxs = centeraxes(map(Base.OneTo, (200, 200)))
+    ϕ1 = tform2deformation(tformrotate(pi / 180), imgaxs, gridsize)
+    ϕ2 = tform2deformation(tformrotate(2pi / 180), imgaxs, gridsize)
     ϕi = interpolate(ϕ1)
     ϕc = ϕi(ϕi)
     uc = reshape(reinterpret(Float64, ϕc.u), (2, gridsize...))
     u2 = reshape(reinterpret(Float64, ϕ2.u), (2, gridsize...))
-    @test ≈(uc, u2, rtol=0.02, norm=x->maximum(abs, x))
+    @test ≈(uc, u2, rtol = 0.02, norm = x -> maximum(abs, x))
 
     ## Test gradient computation
 
     function compare_g(g, gj, gridsize)
-        for j = 1:gridsize[2], i = 1:gridsize[1]
-            indx = (LinearIndices(gridsize))[i,j]
-            rng = 2*(indx-1)+1:2indx
-            @test g[i,j] ≈ gj[rng, rng]
-            for k = 1:2*prod(gridsize)
+        for j in 1:gridsize[2], i in 1:gridsize[1]
+            indx = (LinearIndices(gridsize))[i, j]
+            rng = (2 * (indx - 1) + 1):2indx
+            @test g[i, j] ≈ gj[rng, rng]
+            for k in 1:(2 * prod(gridsize))
                 if !in(k, rng)
-                    @test abs(gj[k,rng[1]]) < 1e-14
-                    @test abs(gj[k,rng[2]]) < 1e-14
+                    @test abs(gj[k, rng[1]]) < 1.0e-14
+                    @test abs(gj[k, rng[2]]) < 1.0e-14
                 end
             end
         end
@@ -247,17 +249,17 @@ end
         ret = Vector{eltype(eltype(ϕ.u))}(undef, prod(shp))
         i = 0
         for vu in ϕ.u
-            for d = 1:length(vu)
-                ret[i+=1] = vu[d]
+            for d in 1:length(vu)
+                ret[i += 1] = vu[d]
             end
         end
         ret
     end
 
-    gridsize = (11,11)
+    gridsize = (11, 11)
     u1 = randn(2, gridsize...)
     u2 = randn(2, gridsize...)
-    imaxs = map(Base.OneTo, (100,101))
+    imaxs = map(Base.OneTo, (100, 101))
     ϕ1 = interpolate(GridDeformation(u1, imaxs))
     for f in (interpolate, identity)
         ϕ2 = f(GridDeformation(u2, imaxs))
@@ -269,16 +271,16 @@ end
 
     # Test identity-composition
     _, g = compose(identity, ϕ2)
-    gj = zeros(2*prod(gridsize), 2*prod(gridsize))
-    for i = 1:prod(gridsize)
-        rng = 2*(i-1)+1:2i
-        gj[rng,rng] = Matrix{Float64}(I,2,2)
+    gj = zeros(2 * prod(gridsize), 2 * prod(gridsize))
+    for i in 1:prod(gridsize)
+        rng = (2 * (i - 1) + 1):2i
+        gj[rng, rng] = Matrix{Float64}(I, 2, 2)
     end
     compare_g(g, gj, gridsize)
 
     # Extrapolation (issue #7)
-    gridsize = (3,3)
-    img = rand(10,10)
+    gridsize = (3, 3)
+    img = rand(10, 10)
     tform = AffineMap(1.3, [0.1, 0.1])
     ϕ = tform2deformation(tform, axes(img), gridsize)
     θ = tform2deformation(tform, axes(img), gridsize)
@@ -288,15 +290,15 @@ end
     ϕθi = interpolate(ϕθ)
     θi = interpolate(θ)
     x = SVector(7, 3)
-    @test norm(ϕθi(x) - tform(tform(x))) <= 2*norm(ϕ(θi(x)) - tform(tform(x)))
+    @test norm(ϕθi(x) - tform(tform(x))) <= 2 * norm(ϕ(θi(x)) - tform(tform(x)))
     x = SVector(3, 7)
-    @test norm(ϕθi(x) - tform(tform(x))) <= 2*norm(ϕ(θi(x)) - tform(tform(x)))
+    @test norm(ϕθi(x) - tform(tform(x))) <= 2 * norm(ϕ(θi(x)) - tform(tform(x)))
 end
 
 @testset "warpgrid" begin
-    nodes = (range(1, stop=100, length=4), range(1, stop=100, length=3))
+    nodes = (range(1, stop = 100, length = 4), range(1, stop = 100, length = 3))
     gridsize = map(length, nodes)
-    ϕ = GridDeformation(5*randn(2,gridsize...), nodes)
+    ϕ = GridDeformation(5 * randn(2, gridsize...), nodes)
     kg = nodegrid(nodes)
     @test eltype(kg) == Bool
     @test size(kg) == (100, 100)
@@ -305,42 +307,42 @@ end
     kg = nodegrid(Float64, nodes)
     @test eltype(kg) == Float64
     A = warpgrid(ϕ)
-    B = warpgrid(ϕ, scale=1.5)
+    B = warpgrid(ϕ, scale = 1.5)
     @test A != B
     @test isa(A, Matrix{Float32})
-    C = warpgrid(ϕ, showidentity=true)
+    C = warpgrid(ϕ, showidentity = true)
     @test eltype(C) == RGB{Float32}
 end
 
 @testset "warp I/O" begin
     # Writing warped data to disk
     o = ones(Float32, 5, 5)
-    A = o .* reshape(1:7, (1,1,7))
+    A = o .* reshape(1:7, (1, 1, 7))
     img = AxisArray(A, :y, :x, :time)
     fn = tempname()
     # With Vector{GridDeformation}
-    ϕs = tighten([GridDeformation(zeros(2,3,3), axes(o)) for i = 1:nimages(img)])
+    ϕs = tighten([GridDeformation(zeros(2, 3, 3), axes(o)) for i in 1:nimages(img)])
     open(fn, "w") do io
-        warp!(io, img, ϕs; eltype=Float32)
+        warp!(io, img, ϕs; eltype = Float32)
     end
     warped = open(fn, "r") do io
         read!(io, Array{Float32}(undef, size(img)))
     end
     @test warped == img
     # With Array{SVector}
-    uarray = reshape(reinterpret(SVector{2,Float64}, zeros(2,3,3,7)), (3,3,7))
+    uarray = reshape(reinterpret(SVector{2, Float64}, zeros(2, 3, 3, 7)), (3, 3, 7))
     open(fn, "w") do io
-        warp!(io, img, uarray; eltype=Float32)
+        warp!(io, img, uarray; eltype = Float32)
     end
     warped = open(fn, "r") do io
         read!(io, Array{Float32}(undef, size(img)))
     end
     @test warped == img
     # With Array{Real}
-    uarray = zeros(2,3,3,7)
+    uarray = zeros(2, 3, 3, 7)
     fn = tempname()
     open(fn, "w") do io
-        warp!(io, img, uarray; eltype=Float32)
+        warp!(io, img, uarray; eltype = Float32)
     end
     warped = open(fn, "r") do io
         read!(io, Array{Float32}(undef, size(img)))
@@ -348,7 +350,7 @@ end
     @test warped == img
     # Multi-process
     open(fn, "w") do io
-        warp!(io, img, uarray; eltype=Float32, nworkers=3)
+        warp!(io, img, uarray; eltype = Float32, nworkers = 3)
     end
     warped = open(fn, "r") do io
         read!(io, Array{Float32}(undef, size(img)))
@@ -358,8 +360,8 @@ end
 
 @testset "Saving deformations" begin
     # Saving arrays-of-staticarrays efficiently
-    nodes = (range(1, stop=20, length=3), range(1, stop=30, length=5))
-    ϕ = GridDeformation(rand(2,map(length,nodes)...), nodes)
+    nodes = (range(1, stop = 20, length = 3), range(1, stop = 30, length = 5))
+    ϕ = GridDeformation(rand(2, map(length, nodes)...), nodes)
     fn = string(tempname(), ".jld2")
     save(fn, "ϕ", ϕ)
     ϕ2 = load(fn, "ϕ")
@@ -383,55 +385,55 @@ end
 @testset "Temporal interpolation" begin
     u2 = [1.0 1.0]
     u4 = [3.0 3.0]
-    nodes = (range(1, stop=20, length=2),)
+    nodes = (range(1, stop = 20, length = 2),)
     ϕ2 = GridDeformation(u2, nodes)
     ϕ4 = GridDeformation(u4, nodes)
     ϕsindex = [ϕ2, ϕ4]
-    ϕs = tinterpolate(ϕsindex, [2,4], 5)
+    ϕs = tinterpolate(ϕsindex, [2, 4], 5)
     @test length(ϕs) == 5
     @test eltype(ϕs) == eltype(ϕsindex)
-    @test all(map(x-> x == @SVector([1.0]), ϕs[1].u))
-    @test all(map(x-> x == @SVector([2.0]), ϕs[3].u))
+    @test all(map(x -> x == @SVector([1.0]), ϕs[1].u))
+    @test all(map(x -> x == @SVector([2.0]), ϕs[3].u))
 end
 
 @testset "Median filtering" begin
     u = rand(2, 3, 3, 9)
-    ϕs = griddeformations(u, (range(1, stop=10, length=3), range(1, stop=11, length=3)))
+    ϕs = griddeformations(u, (range(1, stop = 10, length = 3), range(1, stop = 11, length = 3)))
     ϕsfilt = tmedfilt(ϕs, 3)
-    v = ϕsfilt[3].u[2,2]
-    v1 = median(vec(u[1,2,2,2:4]))
-    v2 = median(vec(u[2,2,2,2:4]))
+    v = ϕsfilt[3].u[2, 2]
+    v1 = median(vec(u[1, 2, 2, 2:4]))
+    v2 = median(vec(u[2, 2, 2, 2:4]))
     @test v[1] == v1 && v[2] == v2
     # in-place variant
     ϕsfilt2 = similar(ϕsfilt)
     tmedfilt!(ϕsfilt2, ϕs, 3)
-    @test ϕsfilt2[3].u[2,2] == v
+    @test ϕsfilt2[3].u[2, 2] == v
 end
 
 @testset "Regridding" begin
-    z = [(x-2.5)^2 for x = 0:5]
-    uold = zeros(2,6,6)
-    uold[1,:,:] = z .* ones(6)'
-    uold[2,:,:] = ones(6) .* z'
-    nodes = (range(1, stop=20, length=6), range(1, stop=30, length=6))
+    z = [(x - 2.5)^2 for x in 0:5]
+    uold = zeros(2, 6, 6)
+    uold[1, :, :] = z .* ones(6)'
+    uold[2, :, :] = ones(6) .* z'
+    nodes = (range(1, stop = 20, length = 6), range(1, stop = 30, length = 6))
     ϕ = GridDeformation(uold, nodes)
-    ϕnew = regrid(ϕ, (10,8))
-    @test ϕnew.nodes[1] ≈ range(1, stop=20, length=10)
-    @test ϕnew.nodes[2] ≈ range(1, stop=30, length=8)
+    ϕnew = regrid(ϕ, (10, 8))
+    @test ϕnew.nodes[1] ≈ range(1, stop = 20, length = 10)
+    @test ϕnew.nodes[2] ≈ range(1, stop = 30, length = 8)
     ϕi = interpolate(ϕ)
-    for (iy,y) in enumerate(range(1, stop=30, length=8))
-        ys = (y-1)*5/29
-        for (ix,x) in enumerate(range(1, stop=20, length=10))
-            xs = (x-1)*5/19
-            @test ≈(ϕnew.u[ix,iy], [(xs-2.5)^2,(ys-2.5)^2], rtol=0.2)
-            @test ϕnew.u[ix,iy] ≈ ϕi.u(x,y)
+    for (iy, y) in enumerate(range(1, stop = 30, length = 8))
+        ys = (y - 1) * 5 / 29
+        for (ix, x) in enumerate(range(1, stop = 20, length = 10))
+            xs = (x - 1) * 5 / 19
+            @test ≈(ϕnew.u[ix, iy], [(xs - 2.5)^2, (ys - 2.5)^2], rtol = 0.2)
+            @test ϕnew.u[ix, iy] ≈ ϕi.u(x, y)
         end
     end
 end
 
 @testset "Equality" begin
     # https://github.com/HolyLab/BlockRegistrationScheduler/pull/42#discussion_r139291426
-    nodes = (range(0, stop=1, length=3), range(0, stop=1, length=5))
+    nodes = (range(0, stop = 1, length = 3), range(0, stop = 1, length = 5))
     u = rand(2, 3, 5)
     ϕ1 = GridDeformation(u, nodes)
     ϕ2 = GridDeformation(u, nodes)
@@ -441,61 +443,63 @@ end
 @testset "Transformation of arrays" begin
     using RegisterDeformation: center
     # TODO: get rid of dependency on ImageFiltering for faster CI times
-    padwith0(A) = parent(padarray(A, Fill(0, (2,2))))
+    padwith0(A) = parent(padarray(A, Fill(0, (2, 2))))
 
-    for IT in ((BSpline(Constant())),
-                    (BSpline(Linear())),
-                    (BSpline(Quadratic(Flat(OnCell())))))
+    for IT in (
+            (BSpline(Constant())),
+            (BSpline(Linear())),
+            (BSpline(Quadratic(Flat(OnCell())))),
+        )
         A = padwith0([1 1; 1 2])
         itp = interpolate(A, IT)
-        tfm = tformtranslate([1,0])
+        tfm = tformtranslate([1, 0])
         tA = TransformedArray(extrapolate(itp, NaN), tfm)
-        @test @inferred(transform(tA))[3:4,3:4] ≈ [1 2; 0 0]
-        @test tA[3,3] ≈ 1
-        @test tA[3,4] ≈ 2
-        tfm = tformtranslate([0,1])
+        @test @inferred(transform(tA))[3:4, 3:4] ≈ [1 2; 0 0]
+        @test tA[3, 3] ≈ 1
+        @test tA[3, 4] ≈ 2
+        tfm = tformtranslate([0, 1])
         tA = TransformedArray(extrapolate(itp, NaN), tfm)
-        @test transform(tA)[3:4,3:4] ≈ [1 0; 2 0]
-        tfm = tformtranslate([-1,0])
+        @test transform(tA)[3:4, 3:4] ≈ [1 0; 2 0]
+        tfm = tformtranslate([-1, 0])
         tA = TransformedArray(extrapolate(itp, NaN), tfm)
-        @test transform(tA)[3:4,3:4] ≈ [0 0; 1 1]
-        tfm = tformtranslate([0,-1])
+        @test transform(tA)[3:4, 3:4] ≈ [0 0; 1 1]
+        tfm = tformtranslate([0, -1])
         tA = TransformedArray(extrapolate(itp, NaN), tfm)
-        @test transform(tA)[3:4,3:4] ≈ [0 1; 0 1]
+        @test transform(tA)[3:4, 3:4] ≈ [0 1; 0 1]
 
         A = padwith0([2 1; 1 1])
         itp = interpolate(A, IT)
-        tfm = tformrotate(pi/2)
+        tfm = tformrotate(pi / 2)
         tA = TransformedArray(extrapolate(itp, NaN), tfm)
-        @test transform(tA)[3:4,3:4] ≈ [1 2; 1 1]
-        tfm = tformrotate(-pi/2)
+        @test transform(tA)[3:4, 3:4] ≈ [1 2; 1 1]
+        tfm = tformrotate(-pi / 2)
         tA = TransformedArray(extrapolate(itp, NaN), tfm)
-        @test transform(tA)[3:4,3:4] ≈ [1 1; 2 1]
+        @test transform(tA)[3:4, 3:4] ≈ [1 1; 2 1]
 
         # Check that getindex and transform yield the same results
-        A = rand(6,6)
+        A = rand(6, 6)
         itp = interpolate(A, IT)
-        tfm = tformrotate(pi/7)∘tformtranslate(rand(2))
+        tfm = tformrotate(pi / 7) ∘ tformtranslate(rand(2))
         tA = TransformedArray(extrapolate(itp, NaN), tfm)
         dest = transform(tA)
-        tfm_recentered = AffineMap(tfm.linear, tfm.translation + center(A) - tfm.linear*center(dest))
+        tfm_recentered = AffineMap(tfm.linear, tfm.translation + center(A) - tfm.linear * center(dest))
         tA_recentered = TransformedArray(extrapolate(itp, NaN), tfm_recentered)
         nbad = 0
-        for j = 1:size(dest,2), i = 1:size(dest,1)
-            val = tA_recentered[i,j]
-            nbad += isfinite(dest[i,j]) != isfinite(val)
-            if isfinite(val) && isfinite(dest[i,j])
-                @test abs(val-dest[i,j]) < 1e-12
+        for j in 1:size(dest, 2), i in 1:size(dest, 1)
+            val = tA_recentered[i, j]
+            nbad += isfinite(dest[i, j]) != isfinite(val)
+            if isfinite(val) && isfinite(dest[i, j])
+                @test abs(val - dest[i, j]) < 1.0e-12
             end
         end
         @test nbad < 3
-        dest = transform(tA, origin_src=zeros(2), origin_dest=zeros(2))
+        dest = transform(tA, origin_src = zeros(2), origin_dest = zeros(2))
         nbad = 0
-        for j = 1:size(dest,2), i = 1:size(dest,1)
-            val = tA[i,j]
-            nbad += isfinite(dest[i,j]) != isfinite(val)
-            if isfinite(val) && isfinite(dest[i,j])
-                @test abs(val-dest[i,j]) < 1e-12
+        for j in 1:size(dest, 2), i in 1:size(dest, 1)
+            val = tA[i, j]
+            nbad += isfinite(dest[i, j]) != isfinite(val)
+            if isfinite(val) && isfinite(dest[i, j])
+                @test abs(val - dest[i, j]) < 1.0e-12
             end
         end
         @test nbad < 3
@@ -503,13 +507,13 @@ end
 
     A = Float64[1 2 3 4; 5 6 7 8]
     tfm = tformeye(2)
-    dest = zeros(2,2)
+    dest = zeros(2, 2)
 
     itp = interpolate(A, BSpline(Linear()))
     tA = TransformedArray(extrapolate(itp, NaN), tfm)
     @test transform!(dest, tA) ≈ [2 3; 6 7]
-    dest3 = zeros(3,3)
-    @test all(isapprox.(transform!(dest3, tA), [NaN NaN NaN; 3.5 4.5 5.5; NaN NaN NaN], nans=true))
+    dest3 = zeros(3, 3)
+    @test all(isapprox.(transform!(dest3, tA), [NaN NaN NaN; 3.5 4.5 5.5; NaN NaN NaN], nans = true))
 
     itp = interpolate(A, BSpline(Constant()))
     tA = TransformedArray(extrapolate(itp, NaN), tfm)
@@ -517,8 +521,8 @@ end
 
     # Transforms with non-real numbers
     using DualNumbers
-    a = tformtranslate([0,dual(1,0)])
+    a = tformtranslate([0, dual(1, 0)])
     A = reshape(1:9, 3, 3)
     At = transform(A, a)
-    @test At[:,1:2] == A[:,2:3]
+    @test At[:, 1:2] == A[:, 2:3]
 end


### PR DESCRIPTION
## Summary
- Run `runic -i` on `src/` and `test/` — formatting only, no functional changes

## Test plan
- [ ] CI passes (all existing tests continue to pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)